### PR TITLE
Shrinkwrap 237 - Multiple reads to same Asset cause IOException StreamClosed/EOF exceptions in ShrinkWrap ClassLoader

### DIFF
--- a/api/src/main/java/org/jboss/shrinkwrap/api/classloader/ShrinkWrapClassLoader.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/classloader/ShrinkWrapClassLoader.java
@@ -23,8 +23,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 
 import org.jboss.shrinkwrap.api.Archive;
@@ -54,10 +54,10 @@ public class ShrinkWrapClassLoader extends URLClassLoader implements Closeable
    //-------------------------------------------------------------------------------------||
 
    /**
-    * Map of all streams opened, such that they may be closed in {@link ShrinkWrapClassLoader#close()}.
+    * List of all streams opened, such that they may be closed in {@link ShrinkWrapClassLoader#close()}.
     * Guarded by "this".
     */
-   private final Map<URL, InputStream> openedStreams = new HashMap<URL, InputStream>();
+   private final List<InputStream> openedStreams = new ArrayList<InputStream>();
 
    //-------------------------------------------------------------------------------------||
    // Constructors -----------------------------------------------------------------------||
@@ -73,8 +73,7 @@ public class ShrinkWrapClassLoader extends URLClassLoader implements Closeable
     */
    public ShrinkWrapClassLoader(final Archive<?>... archives)
    {
-      super(new URL[]
-      {});
+      super(new URL[]{});
 
       if (archives == null)
       {
@@ -93,8 +92,7 @@ public class ShrinkWrapClassLoader extends URLClassLoader implements Closeable
     */
    public ShrinkWrapClassLoader(final ClassLoader parent, final Archive<?>... archives)
    {
-      super(new URL[]
-      {}, parent);
+      super(new URL[]{}, parent);
 
       if (archives == null)
       {
@@ -132,13 +130,9 @@ public class ShrinkWrapClassLoader extends URLClassLoader implements Closeable
                   {
                      synchronized (this)
                      {
-                        InputStream input = openedStreams.get(u);
-                        if (input == null)
-                        {
-                           ArchivePath path = convertToArchivePath(u);
-                           input = archive.get(path).getAsset().openStream();
-                           openedStreams.put(u, input);
-                        }
+                        ArchivePath path = convertToArchivePath(u);
+                        InputStream input = archive.get(path).getAsset().openStream();
+                        openedStreams.add(input);
                         return input;
                      }
                   }
@@ -164,7 +158,7 @@ public class ShrinkWrapClassLoader extends URLClassLoader implements Closeable
    {
       synchronized (this)
       {
-         for (InputStream stream : openedStreams.values())
+         for (InputStream stream : openedStreams)
          {
             try
             {

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/classloader/ShrinkWrapClassLoaderTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/classloader/ShrinkWrapClassLoaderTestCase.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.shrinkwrap.impl.base.classloader;
 
+import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
@@ -25,6 +26,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.classloader.ShrinkWrapClassLoader;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.impl.base.io.IOUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -157,6 +159,33 @@ public class ShrinkWrapClassLoaderTestCase
       // Assertions
       Assert.assertNotNull(resource);
 
+   }
+   
+   /**
+    * SHRINKWRAP-237: Reading the same resource multiple times cause IOException
+    */
+   @Test
+   public void shouldBeAbleToLoadAResourceFromArchiveMultipleTimes() throws Exception
+   {
+      String resourceName = getResourceNameOfClass(applicationClassLoaderClass);
+      
+      // Load the class as a resource
+      URL resource = shrinkWrapClassLoader.getResource(resourceName);
+
+      // Assertions
+      Assert.assertNotNull(resource);
+      
+      // Read the stream until EOF
+      IOUtil.copyWithClose(resource.openStream(), new ByteArrayOutputStream());
+      
+      // Load the class as a resource for the second time
+      resource = shrinkWrapClassLoader.getResource(resourceName);
+
+      // Assertions
+      Assert.assertNotNull(resource);
+
+      // SHRINKWRAP-237: This throws IOException: Stream closed 
+      IOUtil.copyWithClose(resource.openStream(), new ByteArrayOutputStream());
    }
 
    //-------------------------------------------------------------------------------------||


### PR DESCRIPTION
https://jira.jboss.org/browse/SHRINKWRAP-237
