### PR TITLE
MavenDependencyResolver loadReposFromPom() and loadDependenciesFromPom() refactoring

### DIFF
--- a/extension-resolver/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/MavenDependencyResolver.java
+++ b/extension-resolver/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/MavenDependencyResolver.java
@@ -84,8 +84,9 @@ public interface MavenDependencyResolver
     * @return A dependency builder with remote repositories set according to
     *         the content of POM file.
     * @throws Exception
-    * @Deprecated please use {@link #loadMetadataFromPom(String)} instead
+    * @deprecated please use {@link #loadMetadataFromPom(String)} instead
     */
+   @Deprecated
    MavenDependencyResolver loadReposFromPom(String path) throws ResolutionException;
 
    /**
@@ -160,8 +161,9 @@ public interface MavenDependencyResolver
     * @param path
     * @return
     * @throws ResolutionException
-    * @Deprecated please use {@link #includeDependenciesFromPom(String)} instead
+    * @deprecated please use {@link #includeDependenciesFromPom(String)} instead
     */
+   @Deprecated
    MavenDependencyResolver loadDependenciesFromPom(final String path) throws ResolutionException;
 
    /**
@@ -171,8 +173,9 @@ public interface MavenDependencyResolver
     * @param filter
     * @return
     * @throws ResolutionException
-    * @Deprecated please use {@link #includeDependenciesFromPom(String)} instead
+    * @deprecated please use {@link #includeDependenciesFromPom(String)} instead
     */
+   @Deprecated
    MavenDependencyResolver loadDependenciesFromPom(final String path, final MavenResolutionFilter filter)
          throws ResolutionException;
 }

--- a/extension-resolver/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenBuilderImpl.java
+++ b/extension-resolver/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenBuilderImpl.java
@@ -159,7 +159,7 @@ public class MavenBuilderImpl implements MavenDependencyResolverInternal
    }
 
    /**
-    * @Deprecated please use {@link #loadMetadataFromPom(String)} instead
+    * @deprecated please use {@link #loadMetadataFromPom(String)} instead
     */
    @Override
    public MavenDependencyResolver loadReposFromPom(final String path) throws ResolutionException
@@ -184,7 +184,7 @@ public class MavenBuilderImpl implements MavenDependencyResolverInternal
    }
 
    /**
-    * @Deprecated please use {@link #includeDependenciesFromPom(String)} instead
+    * @deprecated please use {@link #includeDependenciesFromPom(String)} instead
     */
    @Override
    public MavenDependencyResolver loadDependenciesFromPom(final String path) throws ResolutionException
@@ -193,7 +193,7 @@ public class MavenBuilderImpl implements MavenDependencyResolverInternal
    }
 
    /**
-    * @Deprecated please use {@link #includeDependenciesFromPom(String)} instead
+    * @deprecated please use {@link #includeDependenciesFromPom(String)} instead
     */
    @Override
    public MavenDependencyResolver loadDependenciesFromPom(final String path, final MavenResolutionFilter filter)
@@ -508,7 +508,7 @@ public class MavenBuilderImpl implements MavenDependencyResolverInternal
       }
 
       /**
-       * @Deprecated please use {@link #loadMetadataFromPom(String)} instead
+       * @deprecated please use {@link #loadMetadataFromPom(String)} instead
        */
       @Override
       public MavenDependencyResolver loadReposFromPom(String path) throws ResolutionException
@@ -565,7 +565,7 @@ public class MavenBuilderImpl implements MavenDependencyResolverInternal
       }
 
       /**
-       * @Deprecated please use {@link #includeDependenciesFromPom(String)} instead
+       * @deprecated please use {@link #includeDependenciesFromPom(String)} instead
        */
       @Override
       public MavenDependencyResolver loadDependenciesFromPom(String path) throws ResolutionException
@@ -574,7 +574,7 @@ public class MavenBuilderImpl implements MavenDependencyResolverInternal
       }
 
       /**
-       * @Deprecated please use {@link #includeDependenciesFromPom(String)} instead
+       * @deprecated please use {@link #includeDependenciesFromPom(String)} instead
        */
       @Override
       public MavenDependencyResolver loadDependenciesFromPom(String path, MavenResolutionFilter filter)
@@ -754,7 +754,7 @@ public class MavenBuilderImpl implements MavenDependencyResolverInternal
       }
 
       /**
-       * @Deprecated please use {@link #loadMetadataFromPom(String)} instead
+       * @deprecated please use {@link #loadMetadataFromPom(String)} instead
        */
       @Override
       public MavenDependencyResolver loadReposFromPom(String path) throws ResolutionException
@@ -825,7 +825,7 @@ public class MavenBuilderImpl implements MavenDependencyResolverInternal
       }
 
       /**
-       * @Deprecated please use {@link #includeDependenciesFromPom(String)} instead
+       * @deprecated please use {@link #includeDependenciesFromPom(String)} instead
        */
       @Override
       public MavenDependencyResolver loadDependenciesFromPom(String path) throws ResolutionException
@@ -834,7 +834,7 @@ public class MavenBuilderImpl implements MavenDependencyResolverInternal
       }
 
       /**
-       * @Deprecated please use {@link #includeDependenciesFromPom(String)} instead
+       * @deprecated please use {@link #includeDependenciesFromPom(String)} instead
        */
       @Override
       public MavenDependencyResolver loadDependenciesFromPom(String path, MavenResolutionFilter filter)

--- a/extension-resolver/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/ExclusionsUnitTestCase.java
+++ b/extension-resolver/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/ExclusionsUnitTestCase.java
@@ -53,15 +53,38 @@ public class ExclusionsUnitTestCase
    {
       String name = "exclusion";
 
-      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-parent.xml")
-                           .artifact("org.jboss.shrinkwrap.test:test-dependency-test:jar:1.0.0")
-                           .scope("test")
-                           .exclusion("org.jboss.shrinkwrap.test:test-deps-f")
-                           .resolveAs(GenericArchive.class, new ScopeFilter("test")));
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class).loadMetadataFromPom("target/poms/test-parent.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-dependency-test:jar:1.0.0").scope("test")
+                  .exclusion("org.jboss.shrinkwrap.test:test-deps-f")
+                  .resolveAs(GenericArchive.class, new ScopeFilter("test")));
 
-      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/" + name + ".tree"), "test");
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/"
+            + name + ".tree"), "test");
+      desc.validateArchive(war).results();
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
+
+   /**
+    * Tests exclusion of the artifacts
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testExclusionDeprecated() throws ResolutionException
+   {
+      String name = "exclusion";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class).loadReposFromPom("target/poms/test-parent.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-dependency-test:jar:1.0.0").scope("test")
+                  .exclusion("org.jboss.shrinkwrap.test:test-deps-f")
+                  .resolveAs(GenericArchive.class, new ScopeFilter("test")));
+
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/"
+            + name + ".tree"), "test");
       desc.validateArchive(war).results();
 
       war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
@@ -77,15 +100,38 @@ public class ExclusionsUnitTestCase
    {
       String name = "exclusions";
 
-      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-parent.xml")
-                           .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0")
-                           .scope("test")
-                           .exclusions("org.jboss.shrinkwrap.test:test-deps-f", "org.jboss.shrinkwrap.test:test-deps-g")
-                           .resolveAs(GenericArchive.class, new ScopeFilter("test")));
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class).loadMetadataFromPom("target/poms/test-parent.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0").scope("test")
+                  .exclusions("org.jboss.shrinkwrap.test:test-deps-f", "org.jboss.shrinkwrap.test:test-deps-g")
+                  .resolveAs(GenericArchive.class, new ScopeFilter("test")));
 
-      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/" + name + ".tree"), "test");
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/"
+            + name + ".tree"), "test");
+      desc.validateArchive(war).results();
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
+
+   /**
+    * Tests exclusion of the artifacts
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testExclusionsDeprecated() throws ResolutionException
+   {
+      String name = "exclusions";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class).loadReposFromPom("target/poms/test-parent.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0").scope("test")
+                  .exclusions("org.jboss.shrinkwrap.test:test-deps-f", "org.jboss.shrinkwrap.test:test-deps-g")
+                  .resolveAs(GenericArchive.class, new ScopeFilter("test")));
+
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/"
+            + name + ".tree"), "test");
       desc.validateArchive(war).results();
 
       war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
@@ -100,13 +146,30 @@ public class ExclusionsUnitTestCase
 
       File[] files = DependencyResolvers.use(MavenDependencyResolver.class)
             .loadMetadataFromPom("target/poms/test-parent.xml")
-            .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0")
-            .scope("test")
-            .exclusion("*")
+            .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0").scope("test").exclusion("*")
             .resolveAsFiles(new ScopeFilter("test"));
 
       Assert.assertEquals("There is only one jar in the package", 1, files.length);
-      Assert.assertEquals("The file is packaged as test-dependency-test-1.0.0.jar", "test-dependency-test-1.0.0.jar", files[0].getName());
+      Assert.assertEquals("The file is packaged as test-dependency-test-1.0.0.jar", "test-dependency-test-1.0.0.jar",
+            files[0].getName());
+   }
+
+   /**
+    * Tests exclusion of all transitive artifacts
+    */
+   @Test
+   @Deprecated
+   public void testUniversalExclusionDeprecated()
+   {
+
+      File[] files = DependencyResolvers.use(MavenDependencyResolver.class)
+            .loadReposFromPom("target/poms/test-parent.xml")
+            .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0").scope("test").exclusion("*")
+            .resolveAsFiles(new ScopeFilter("test"));
+
+      Assert.assertEquals("There is only one jar in the package", 1, files.length);
+      Assert.assertEquals("The file is packaged as test-dependency-test-1.0.0.jar", "test-dependency-test-1.0.0.jar",
+            files[0].getName());
    }
 
 }

--- a/extension-resolver/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenResolutionFilterUnitTestCase.java
+++ b/extension-resolver/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenResolutionFilterUnitTestCase.java
@@ -61,11 +61,36 @@ public class MavenResolutionFilterUnitTestCase
    {
       String name = "strictFilter";
 
-      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-child.xml")
-                           .artifact("org.jboss.shrinkwrap.test:test-child:1.0.0")
-                           .resolveAs(GenericArchive.class,new StrictFilter()));
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class).loadMetadataFromPom("target/poms/test-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-child:1.0.0")
+                  .resolveAs(GenericArchive.class, new StrictFilter()));
+
+      Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
+
+      Assert.assertEquals("There is only one jar in the package", 1, map.size());
+      Assert.assertTrue("The artifact is packaged as test-child:1.0.0",
+            map.containsKey(ArchivePaths.create("WEB-INF/lib/test-child-1.0.0.jar")));
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+
+   }
+
+   /**
+    * Tests that only directly defined artifacts are added to dependencies
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testStrictFilterDeprecated() throws ResolutionException
+   {
+      String name = "strictFilter";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class).loadReposFromPom("target/poms/test-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-child:1.0.0")
+                  .resolveAs(GenericArchive.class, new StrictFilter()));
 
       Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
 
@@ -88,11 +113,39 @@ public class MavenResolutionFilterUnitTestCase
    {
       String name = "strictFilterInferredVersion";
 
-      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
                   .loadMetadataFromPom("target/poms/test-remote-child.xml")
                   .artifact("org.jboss.shrinkwrap.test:test-deps-c")
-                  .resolveAs(GenericArchive.class,new StrictFilter()));
+                  .resolveAs(GenericArchive.class, new StrictFilter()));
+
+      Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
+
+      Assert.assertEquals("There is only one jar in the package", 1, map.size());
+      Assert.assertTrue("The artifact is packaged as test-deps-c:1.0.0",
+            map.containsKey(ArchivePaths.create("WEB-INF/lib/test-deps-c-1.0.0.jar")));
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+
+   }
+
+   /**
+    * Tests that only directly defined artifacts are added to dependencies, the
+    * artifact version is taken from a POM file
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testStrictFilterInferredVersionDeprecated() throws ResolutionException
+   {
+      String name = "strictFilterInferredVersion";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadReposFromPom("target/poms/test-remote-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-deps-c")
+                  .resolveAs(GenericArchive.class, new StrictFilter()));
 
       Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
 
@@ -115,7 +168,34 @@ public class MavenResolutionFilterUnitTestCase
       String name = "defaultScopeFilter";
 
       WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
-            DependencyResolvers.use(MavenDependencyResolver.class).loadMetadataFromPom("target/poms/test-remote-child.xml")
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadMetadataFromPom("target/poms/test-remote-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-remote-child:1.0.0")
+                  .resolveAs(GenericArchive.class, new ScopeFilter()));
+
+      Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
+
+      Assert.assertEquals("There is one jar in the package", 1, map.size());
+      Assert.assertTrue("The artifact is packaged as test-remote-child:1.0.0",
+            map.containsKey(ArchivePaths.create("WEB-INF/lib/test-remote-child-1.0.0.jar")));
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
+
+   /**
+    * Tests loading of a POM file with parent not available on local file system
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testDefaultScopeFilterDeprecated() throws ResolutionException
+   {
+      String name = "defaultScopeFilter";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadReposFromPom("target/poms/test-remote-child.xml")
                   .artifact("org.jboss.shrinkwrap.test:test-remote-child:1.0.0")
                   .resolveAs(GenericArchive.class, new ScopeFilter()));
 
@@ -138,11 +218,35 @@ public class MavenResolutionFilterUnitTestCase
    {
       String name = "runtimeScopeFilter";
 
-      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-parent.xml")
-                           .artifact("org.jboss.shrinkwrap.test:test-dependency:1.0.0")
-                           .resolveAs(GenericArchive.class, new ScopeFilter("runtime")));
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class).loadMetadataFromPom("target/poms/test-parent.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-dependency:1.0.0")
+                  .resolveAs(GenericArchive.class, new ScopeFilter("runtime")));
+
+      Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
+
+      Assert.assertEquals("There is one jar in the package", 1, map.size());
+      Assert.assertTrue("The artifact is packaged as test-deps-b:1.0.0",
+            map.containsKey(ArchivePaths.create("WEB-INF/lib/test-deps-b-1.0.0.jar")));
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
+
+   /**
+    * Tests limiting of the scope
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testRuntimeScopeFilterDeprecated() throws ResolutionException
+   {
+      String name = "runtimeScopeFilter";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class).loadReposFromPom("target/poms/test-parent.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-dependency:1.0.0")
+                  .resolveAs(GenericArchive.class, new ScopeFilter("runtime")));
 
       Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
 
@@ -164,12 +268,48 @@ public class MavenResolutionFilterUnitTestCase
       String name = "testCombinedScopeFilter";
 
       WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-parent.xml")
-                           .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0")
-                           .scope("test")
-                           .artifact("org.jboss.shrinkwrap.test:test-dependency:1.0.0")
-                           .resolveAs(GenericArchive.class,new CombinedFilter(new ScopeFilter("", "test"), new StrictFilter())));
+            .addAsLibraries(
+                  DependencyResolvers
+                        .use(MavenDependencyResolver.class)
+                        .loadMetadataFromPom("target/poms/test-parent.xml")
+                        .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0")
+                        .scope("test")
+                        .artifact("org.jboss.shrinkwrap.test:test-dependency:1.0.0")
+                        .resolveAs(GenericArchive.class,
+                              new CombinedFilter(new ScopeFilter("", "test"), new StrictFilter())));
+
+      Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
+
+      Assert.assertEquals("There are two jars in the package", 2, map.size());
+      Assert.assertTrue("The artifact is packaged as org.jboss.shrinkwrapt.test:test-dependency-test:1.0.0",
+            map.containsKey(ArchivePaths.create("WEB-INF/lib/test-dependency-test-1.0.0.jar")));
+      Assert.assertTrue("The artifact is packaged as org.jboss.shrinkwrapt.test:test-dependency:1.0.0",
+            map.containsKey(ArchivePaths.create("WEB-INF/lib/test-dependency-1.0.0.jar")));
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
+
+   /**
+    * Tests limiting of the scope and strict artifacts
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testCombinedScopeFilterDeprecated() throws ResolutionException
+   {
+      String name = "testCombinedScopeFilter";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
+            .addAsLibraries(
+                  DependencyResolvers
+                        .use(MavenDependencyResolver.class)
+                        .loadReposFromPom("target/poms/test-parent.xml")
+                        .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0")
+                        .scope("test")
+                        .artifact("org.jboss.shrinkwrap.test:test-dependency:1.0.0")
+                        .resolveAs(GenericArchive.class,
+                              new CombinedFilter(new ScopeFilter("", "test"), new StrictFilter())));
 
       Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
 
@@ -192,12 +332,43 @@ public class MavenResolutionFilterUnitTestCase
    {
       String name = "testCombinedScopeFilter2";
 
-      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-parent.xml")
-                           .artifacts("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0", "org.jboss.shrinkwrap.test:test-dependency:1.0.0")
-                           .scope("test")
-                           .resolveAs(GenericArchive.class,new CombinedFilter(new ScopeFilter("test"), new StrictFilter())));
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers
+                  .use(MavenDependencyResolver.class)
+                  .loadMetadataFromPom("target/poms/test-parent.xml")
+                  .artifacts("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0",
+                        "org.jboss.shrinkwrap.test:test-dependency:1.0.0").scope("test")
+                  .resolveAs(GenericArchive.class, new CombinedFilter(new ScopeFilter("test"), new StrictFilter())));
+
+      Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
+
+      Assert.assertEquals("There are two jars in the package", 2, map.size());
+      Assert.assertTrue("The artifact is packaged as org.jboss.shrinkwrapt.test:test-dependency-test:1.0.0",
+            map.containsKey(ArchivePaths.create("WEB-INF/lib/test-dependency-test-1.0.0.jar")));
+      Assert.assertTrue("The artifact is packaged as org.jboss.shrinkwrapt.test:test-dependency:1.0.0",
+            map.containsKey(ArchivePaths.create("WEB-INF/lib/test-dependency-1.0.0.jar")));
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
+
+   /**
+    * Tests limiting of the scope and strict artifacts. Uses artifacts() method
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testCombinedScopeFilter2Deprecated() throws ResolutionException
+   {
+      String name = "testCombinedScopeFilter2";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers
+                  .use(MavenDependencyResolver.class)
+                  .loadReposFromPom("target/poms/test-parent.xml")
+                  .artifacts("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0",
+                        "org.jboss.shrinkwrap.test:test-dependency:1.0.0").scope("test")
+                  .resolveAs(GenericArchive.class, new CombinedFilter(new ScopeFilter("test"), new StrictFilter())));
 
       Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
 
@@ -221,13 +392,48 @@ public class MavenResolutionFilterUnitTestCase
       String name = "testCombinedScopeFilter3";
 
       WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-parent.xml")
-                           .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0")
-                           .scope("test")
-                           .artifact("org.jboss.shrinkwrap.test:test-dependency:1.0.0")
-                           .scope("provided")
-                           .resolveAs(GenericArchive.class,new CombinedFilter(new ScopeFilter("provided"), new StrictFilter())));
+            .addAsLibraries(
+                  DependencyResolvers
+                        .use(MavenDependencyResolver.class)
+                        .loadMetadataFromPom("target/poms/test-parent.xml")
+                        .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0")
+                        .scope("test")
+                        .artifact("org.jboss.shrinkwrap.test:test-dependency:1.0.0")
+                        .scope("provided")
+                        .resolveAs(GenericArchive.class,
+                              new CombinedFilter(new ScopeFilter("provided"), new StrictFilter())));
+
+      Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
+
+      Assert.assertEquals("There is one jar in the package", 1, map.size());
+      Assert.assertTrue("The artifact is packaged as org.jboss.shrinkwrap.test:test-dependency:1.0.0",
+            map.containsKey(ArchivePaths.create("WEB-INF/lib/test-dependency-1.0.0.jar")));
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
+
+   /**
+    * Tests limiting of the scope and strict artifacts
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testCombinedScopeFilter3Deprecated() throws ResolutionException
+   {
+      String name = "testCombinedScopeFilter3";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
+            .addAsLibraries(
+                  DependencyResolvers
+                        .use(MavenDependencyResolver.class)
+                        .loadReposFromPom("target/poms/test-parent.xml")
+                        .artifact("org.jboss.shrinkwrap.test:test-dependency-test:1.0.0")
+                        .scope("test")
+                        .artifact("org.jboss.shrinkwrap.test:test-dependency:1.0.0")
+                        .scope("provided")
+                        .resolveAs(GenericArchive.class,
+                              new CombinedFilter(new ScopeFilter("provided"), new StrictFilter())));
 
       Map<ArchivePath, Node> map = war.getContent(JAR_FILTER);
 
@@ -250,28 +456,53 @@ public class MavenResolutionFilterUnitTestCase
       String name = "pomBasedDependenciesWithScope";
 
       WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
-            DependencyResolvers.use(MavenDependencyResolver.class).includeDependenciesFromPom("target/poms/test-child.xml")
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .includeDependenciesFromPom("target/poms/test-child.xml")
                   .resolveAs(JavaArchive.class, new ScopeFilter("test")));
 
-      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/test-child.tree"), "test");
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-child.tree"), "test");
       desc.validateArchive(war).results();
 
       war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
 
+   /**
+    * Tests resolution of dependencies for a POM file with parent on local file
+    * system
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testPomBasedDependenciesWithScopeDeprecated() throws ResolutionException
+   {
+      String name = "pomBasedDependenciesWithScope";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadDependenciesFromPom("target/poms/test-child.xml")
+                  .resolveAs(JavaArchive.class, new ScopeFilter("test")));
+
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-child.tree"), "test");
+      desc.validateArchive(war).results();
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
    }
 
    // filter to retrieve jar files only
    private static final Filter<ArchivePath> JAR_FILTER = new Filter<ArchivePath>()
    {
       public boolean include(ArchivePath object)
+      {
+         if (object.get().endsWith(".jar"))
          {
-            if (object.get().endsWith(".jar"))
-            {
-               return true;
-            }
-
-            return false;
+            return true;
          }
+
+         return false;
+      }
    };
 
 }

--- a/extension-resolver/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/PomDependenciesUnitTestCase.java
+++ b/extension-resolver/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/PomDependenciesUnitTestCase.java
@@ -51,13 +51,35 @@ public class PomDependenciesUnitTestCase
    {
       String name = "parentPomRepositories";
 
-      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-child.xml")
-                           .artifact("org.jboss.shrinkwrap.test:test-child:1.0.0")
-                           .resolveAs(GenericArchive.class));
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class).loadMetadataFromPom("target/poms/test-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-child:1.0.0").resolveAs(GenericArchive.class));
 
-      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/test-child.tree"), "compile");
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-child.tree"), "compile");
+      desc.validateArchive(war).results();
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+
+   }
+
+   /**
+    * Tests loading of a POM file with parent not available on local file system
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testParentPomRepositoriesDeprecated() throws ResolutionException
+   {
+      String name = "parentPomRepositories";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class).loadReposFromPom("target/poms/test-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-child:1.0.0").resolveAs(GenericArchive.class));
+
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-child.tree"), "compile");
       desc.validateArchive(war).results();
 
       war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
@@ -74,13 +96,36 @@ public class PomDependenciesUnitTestCase
    {
       String name = "parentPomRemoteRepositories";
 
-      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-remote-child.xml")
-                           .artifact("org.jboss.shrinkwrap.test:test-deps-c:1.0.0")
-                           .resolveAs(GenericArchive.class));
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadMetadataFromPom("target/poms/test-remote-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-deps-c:1.0.0").resolveAs(GenericArchive.class));
 
-      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/test-deps-c.tree"));
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-deps-c.tree"));
+      desc.validateArchive(war).results();
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
+
+   /**
+    * Tests loading of a POM file with parent available on local file system
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testParentPomRemoteRepositoriesDeprecated() throws ResolutionException
+   {
+      String name = "parentPomRemoteRepositories";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadReposFromPom("target/poms/test-remote-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-deps-c:1.0.0").resolveAs(GenericArchive.class));
+
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-deps-c.tree"));
       desc.validateArchive(war).results();
 
       war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
@@ -97,13 +142,37 @@ public class PomDependenciesUnitTestCase
    {
       String name = "artifactVersionRetrievalFromPom";
 
-      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-remote-child.xml")
-                           .artifact("org.jboss.shrinkwrap.test:test-deps-c")
-                           .resolveAs(GenericArchive.class));
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadMetadataFromPom("target/poms/test-remote-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-deps-c").resolveAs(GenericArchive.class));
 
-      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/test-deps-c.tree"));
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-deps-c.tree"));
+      desc.validateArchive(war).results();
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
+
+   /**
+    * Tests loading of a POM file with parent available on local file system
+    * Uses POM to get artifact version
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testArtifactVersionRetrievalFromPomDeprecated() throws ResolutionException
+   {
+      String name = "artifactVersionRetrievalFromPom";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadReposFromPom("target/poms/test-remote-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-deps-c").resolveAs(GenericArchive.class));
+
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-deps-c.tree"));
       desc.validateArchive(war).results();
 
       war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
@@ -121,13 +190,38 @@ public class PomDependenciesUnitTestCase
    {
       String name = "artifactVersionRetrievalFromPomOverride";
 
-      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war")
-            .addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
-                           .loadMetadataFromPom("target/poms/test-remote-child.xml")
-                           .artifact("org.jboss.shrinkwrap.test:test-deps-c:2.0.0")
-                           .resolveAs(GenericArchive.class));
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadMetadataFromPom("target/poms/test-remote-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-deps-c:2.0.0").resolveAs(GenericArchive.class));
 
-      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/test-deps-c-2.tree"));
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-deps-c-2.tree"));
+      desc.validateArchive(war).results();
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
+
+   /**
+    * Tests loading of a POM file with parent available on local file system.
+    * However, the artifact version is not used from there, but specified
+    * manually
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testArtifactVersionRetrievalFromPomOverrideDeprecated() throws ResolutionException
+   {
+      String name = "artifactVersionRetrievalFromPomOverride";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadReposFromPom("target/poms/test-remote-child.xml")
+                  .artifact("org.jboss.shrinkwrap.test:test-deps-c:2.0.0").resolveAs(GenericArchive.class));
+
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-deps-c-2.tree"));
       desc.validateArchive(war).results();
 
       war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
@@ -145,10 +239,35 @@ public class PomDependenciesUnitTestCase
       String name = "pomBasedDependencies";
 
       WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
-            DependencyResolvers.use(MavenDependencyResolver.class).includeDependenciesFromPom("target/poms/test-child.xml")
-                  .resolveAs(JavaArchive.class));
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .includeDependenciesFromPom("target/poms/test-child.xml").resolveAs(JavaArchive.class));
 
-      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/test-child.tree"));
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-child.tree"));
+      desc.validateArchive(war).results();
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+
+   }
+
+   /**
+    * Tests resolution of dependencies for a POM file with parent on local file
+    * system
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testPomBasedDependenciesDeprecated() throws ResolutionException
+   {
+      String name = "pomBasedDependencies";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadDependenciesFromPom("target/poms/test-child.xml").resolveAs(JavaArchive.class));
+
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-child.tree"));
       desc.validateArchive(war).results();
 
       war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
@@ -167,13 +286,36 @@ public class PomDependenciesUnitTestCase
       String name = "pomRemoteBasedDependencies";
 
       WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
-            DependencyResolvers.use(MavenDependencyResolver.class).includeDependenciesFromPom("target/poms/test-remote-child.xml")
-                  .resolveAs(JavaArchive.class));
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .includeDependenciesFromPom("target/poms/test-remote-child.xml").resolveAs(JavaArchive.class));
 
-      DependencyTreeDescription desc = new DependencyTreeDescription(new File("src/test/resources/dependency-trees/test-remote-child.tree"));
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-remote-child.tree"));
       desc.validateArchive(war).results();
 
       war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
+   }
 
+   /**
+    * Tests resolution of dependencies for a POM file without parent on local
+    * file system
+    * 
+    * @throws ResolutionException
+    */
+   @Test
+   @Deprecated
+   public void testPomRemoteBasedDependenciesDeprecated() throws ResolutionException
+   {
+      String name = "pomRemoteBasedDependencies";
+
+      WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war").addAsLibraries(
+            DependencyResolvers.use(MavenDependencyResolver.class)
+                  .loadDependenciesFromPom("target/poms/test-remote-child.xml").resolveAs(JavaArchive.class));
+
+      DependencyTreeDescription desc = new DependencyTreeDescription(new File(
+            "src/test/resources/dependency-trees/test-remote-child.tree"));
+      desc.validateArchive(war).results();
+
+      war.as(ZipExporter.class).exportTo(new File("target/" + name + ".war"), true);
    }
 }


### PR DESCRIPTION
[SHRINKWRAP-268] MavenDependencyResolver loadReposFromPom() and loadDependenciesFromPom() method names are misleading.
