### PR TITLE
SHRINKWRAP-402 Add support for checking the type of the Archive

### DIFF
--- a/api/src/main/java/org/jboss/shrinkwrap/api/Archive.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/Archive.java
@@ -321,6 +321,14 @@ public interface Archive<T extends Archive<T>> extends Assignable {
         ArchiveFormat archiveFormat);
 
     /**
+     * Check if this Archive is of a specific type, e.g. WebArchive or EnterpriseArchive.
+     *
+     * @param archiveType The archive type to check against
+     * @return true if the default extension of the given archiveType match the extension of this archive
+     */
+    boolean isOfType(Class<? extends Archive<?>> archiveType);
+
+    /**
      * Denotes whether this archive contains a resource at the specified path
      *
      * @param path

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/ArchiveBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/ArchiveBase.java
@@ -37,6 +37,7 @@ import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.IllegalArchivePathException;
 import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.UnknownExtensionTypeException;
 import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.NamedAsset;
@@ -331,6 +332,21 @@ public abstract class ArchiveBase<T extends Archive<T>> implements Archive<T>, C
     /**
      * {@inheritDoc}
      *
+     * @see org.jboss.shrinkwrap.api.Archive#isOfType(java.lang.Class)
+     */
+    @Override
+    public boolean isOfType(Class<? extends Archive<?>> archiveType) {
+        try {
+            String extension = this.configuration.getExtensionLoader().getExtensionFromExtensionMapping(archiveType);
+            return getName().endsWith(extension);
+        } catch (UnknownExtensionTypeException e) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.jboss.shrinkwrap.api.Archive#add(org.jboss.shrinkwrap.api.Archive, org.jboss.shrinkwrap.api.ArchivePath,
      *      java.lang.Class)
      */
@@ -424,6 +440,7 @@ public abstract class ArchiveBase<T extends Archive<T>> implements Archive<T>, C
      *
      * @see org.jboss.shrinkwrap.api.Archive#getName()
      */
+    @Override
     public final String getName() {
         return name;
     }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
@@ -479,6 +479,16 @@ public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase
     /**
      * {@inheritDoc}
      *
+     * @see org.jboss.shrinkwrap.api.Archive#isOfType(java.lang.Class)
+     */
+    @Override
+    public boolean isOfType(Class<? extends Archive<?>> archiveType) {
+        return this.getArchive().isOfType(archiveType);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.jboss.shrinkwrap.api.Archive#getContent()
      */
     @Override

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/EnterpriseArchiveImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/EnterpriseArchiveImplTestCase.java
@@ -77,6 +77,11 @@ public class EnterpriseArchiveImplTestCase extends DynamicEnterpriseContainerTes
     // Required Impls - ArchiveTestBase ---------------------------------------------------||
     // -------------------------------------------------------------------------------------||
 
+    @Override
+    protected Class<EnterpriseArchive> getExpectedArchiveType() {
+        return EnterpriseArchive.class;
+    }
+
     /**
      * Return the current EnterpriseArchive
      */

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/GenericArchiveImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/GenericArchiveImplTestCase.java
@@ -74,6 +74,11 @@ public class GenericArchiveImplTestCase extends DynamicContainerTestBase<Generic
     // Required Impls - ArchiveTestBase ---------------------------------------------------||
     // -------------------------------------------------------------------------------------||
 
+    @Override
+    protected Class<GenericArchive> getExpectedArchiveType() {
+        return GenericArchive.class;
+    }
+
     /**
      * Return the archive to super class
      */

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/JavaArchiveImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/JavaArchiveImplTestCase.java
@@ -73,6 +73,10 @@ public class JavaArchiveImplTestCase extends DynamicContainerTestBase<JavaArchiv
     // Required Impls - ArchiveTestBase ---------------------------------------------------||
     // -------------------------------------------------------------------------------------||
 
+    protected Class<JavaArchive> getExpectedArchiveType() {
+        return JavaArchive.class;
+    }
+
     /**
      * Return the archive to super class
      */

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/ResourceAdapterArchiveImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/ResourceAdapterArchiveImplTestCase.java
@@ -78,6 +78,10 @@ public class ResourceAdapterArchiveImplTestCase extends DynamicResourceAdapterCo
     // Required Impls - ArchiveTestBase ---------------------------------------------------||
     // -------------------------------------------------------------------------------------||
 
+    protected Class<ResourceAdapterArchive> getExpectedArchiveType() {
+        return ResourceAdapterArchive.class;
+    }
+
     /**
      * Return the current ResourceAdapterArchive
      */

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/WebArchiveImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/WebArchiveImplTestCase.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.shrinkwrap.impl.base.spec;
 
+import junit.framework.Assert;
+
 import org.jboss.shrinkwrap.api.ArchiveFormat;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ArchivePaths;
@@ -26,11 +28,15 @@ import org.jboss.shrinkwrap.api.container.ManifestContainer;
 import org.jboss.shrinkwrap.api.container.ResourceContainer;
 import org.jboss.shrinkwrap.api.container.ServiceProviderContainer;
 import org.jboss.shrinkwrap.api.container.WebContainer;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.impl.base.test.ArchiveType;
 import org.jboss.shrinkwrap.impl.base.test.DynamicWebContainerTestBase;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 /**
  * WebArchiveImplTestCase
@@ -83,6 +89,11 @@ public class WebArchiveImplTestCase extends DynamicWebContainerTestBase<WebArchi
     // -------------------------------------------------------------------------------------||
     // Required Impls - ArchiveTestBase ---------------------------------------------------||
     // -------------------------------------------------------------------------------------||
+
+    @Override
+    protected Class<WebArchive> getExpectedArchiveType() {
+        return WebArchive.class;
+    }
 
     @Override
     protected WebArchive getArchive() {

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/ArchiveTestBase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/ArchiveTestBase.java
@@ -46,6 +46,7 @@ import org.jboss.shrinkwrap.api.asset.NamedAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.impl.base.TestIOUtil;
 import org.jboss.shrinkwrap.impl.base.Validate;
 import org.jboss.shrinkwrap.impl.base.io.IOUtil;
@@ -54,6 +55,7 @@ import org.jboss.shrinkwrap.impl.base.test.handler.ReplaceAssetHandler;
 import org.jboss.shrinkwrap.impl.base.test.handler.SimpleHandler;
 import org.jboss.shrinkwrap.spi.ArchiveFormatAssociable;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -101,9 +103,17 @@ public abstract class ArchiveTestBase<T extends Archive<T>> {
 
     protected abstract ArchiveFormat getExpectedArchiveFormat();
 
+    protected abstract Class<T> getExpectedArchiveType();
+
     // -------------------------------------------------------------------------------------||
     // Tests ------------------------------------------------------------------------------||
     // -------------------------------------------------------------------------------------||
+
+    @Test
+    public void shouldBeOfType() throws Exception {
+        Assume.assumeNotNull(getExpectedArchiveType()); // assume not null, e.g. MemoryMapArchive is not a type
+        Assert.assertTrue("Should be archive of type " + getExpectedArchiveType(), getArchive().isOfType(getExpectedArchiveType()));            
+    }
 
     @Test
     public void testDefaultArchiveFormatIsSet() throws Exception {

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/unit/MemoryMapArchiveTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/unit/MemoryMapArchiveTestCase.java
@@ -38,6 +38,11 @@ import org.junit.Test;
 public class MemoryMapArchiveTestCase extends ArchiveTestBase<MemoryMapArchive> {
     private MemoryMapArchive archive;
 
+    @Override
+    protected Class<MemoryMapArchive> getExpectedArchiveType() {
+        return null;
+    }
+
     /**
      * Create a new Archive instance per Test.
      *


### PR DESCRIPTION
The new method Archive.isOfType(Class<? extends Archive<?>>) can be used to verify if a given Archive is of a given ArchiveType.
The check matches the Archive.name against the ArchiveTypes extension mapping.

ShrinkWrap.create(JavaArchive.class).isOfType(WebArchive.class) == false
ShrinkWrap.create(JavaArchive.class, "my.war").isOfType(WebArchive.class) == true
ShrinkWrap.create(MySpecialWebArchive.class, "my.war").isOfType(WebArchive.class) == true
