### PR TITLE
[SHRINKWRAP-404] Expose underlying Asset source in the individual APIs

### DIFF
--- a/api/src/main/java/org/jboss/shrinkwrap/api/asset/ClassAsset.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/asset/ClassAsset.java
@@ -78,6 +78,14 @@ public class ClassAsset implements Asset {
     }
 
     /**
+     * Returns the loaded class.
+     *
+     */
+    public Class<?> getSource() {
+        return clazz;
+    }
+
+    /**
      * Returns the name of the class such that it may be accessed via ClassLoader.getResource()
      *
      * @param clazz

--- a/api/src/main/java/org/jboss/shrinkwrap/api/asset/ClassLoaderAsset.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/asset/ClassLoaderAsset.java
@@ -17,6 +17,7 @@
 package org.jboss.shrinkwrap.api.asset;
 
 import java.io.BufferedInputStream;
+import java.io.File;
 import java.io.InputStream;
 
 /**
@@ -72,6 +73,14 @@ public class ClassLoaderAsset implements Asset {
 
         this.resourceName = resourceName;
         this.classLoader = classLoader;
+    }
+
+    /**
+     * Returns the loaded resource.
+     *
+     */
+    public String getSource() {
+        return this.resourceName;
     }
 
     /**

--- a/api/src/main/java/org/jboss/shrinkwrap/api/asset/FileAsset.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/asset/FileAsset.java
@@ -54,7 +54,7 @@ public class FileAsset implements Asset {
     /**
      * Opens a new FileInputStream for the given File.
      *
-     * Can throw a Runtime exception if the file has been deleted inbetween the FileResource was created and the stream
+     * Can throw a Runtime exception if the file has been deleted in between the FileResource was created and the stream
      * is opened.
      *
      * @throws RuntimeException
@@ -68,6 +68,14 @@ public class FileAsset implements Asset {
             throw new RuntimeException("Could not open file " + file, e);
         }
     }
+
+    /**
+     * Returns the loaded file.
+     *
+     */
+     public File getSource() {
+         return this.file;
+     }
 
     /**
      * {@inheritDoc}

--- a/api/src/test/java/org/jboss/shrinkwrap/api/asset/ClassAssetTestCase.java
+++ b/api/src/test/java/org/jboss/shrinkwrap/api/asset/ClassAssetTestCase.java
@@ -71,4 +71,12 @@ public class ClassAssetTestCase {
                 IllegalArgumentException.class, e.getClass());
         }
     }
+    
+    @Test
+    public void shouldBeAbleToReturnThisClass() throws Exception {
+        final Class<?> clazz = ClassAssetTestCase.class;
+        final Asset asset = new ClassAsset(clazz);
+        
+        Assert.assertTrue(clazz.getName().equals(((ClassAsset)asset).getSource().getName()));
+    }
 }

--- a/api/src/test/java/org/jboss/shrinkwrap/api/asset/ClassLoaderAssetTestCase.java
+++ b/api/src/test/java/org/jboss/shrinkwrap/api/asset/ClassLoaderAssetTestCase.java
@@ -78,4 +78,11 @@ public class ClassLoaderAssetTestCase {
                 IllegalArgumentException.class, e.getClass());
         }
     }
+    
+    @Test
+    public void shouldBeAbleToReturnResource() throws Exception {
+        final Asset asset = new ClassLoaderAsset(EXISTING_RESOURCE);
+        
+        Assert.assertEquals(((ClassLoaderAsset)asset).getSource(), EXISTING_RESOURCE);
+    }
 }

--- a/api/src/test/java/org/jboss/shrinkwrap/api/asset/FileAssetTestCase.java
+++ b/api/src/test/java/org/jboss/shrinkwrap/api/asset/FileAssetTestCase.java
@@ -69,4 +69,12 @@ public class FileAssetTestCase {
                 IllegalArgumentException.class, e.getClass());
         }
     }
+    
+    @Test
+    public void shouldBeAbleToReturnFile() throws Exception {
+    	final File exitingFile = new File(EXISTING_FILE);
+    	final Asset asset = new FileAsset(exitingFile);
+    	
+        Assert.assertTrue(exitingFile.equals(((FileAsset)asset).getSource()));
+    }
 }


### PR DESCRIPTION
Thanks Andrew and Aslak

This was simple ... probably too simple. Let me know if I have misunderstood the instructions and I will correct it. I spend probably more time with correcting the code checker. Do you intend to introduce this for the descriptor project too?
