### PR TITLE
SHRINKWRAP-432 Fix shallowCopy() for nested assets.

### DIFF
--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/ArchiveBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/ArchiveBase.java
@@ -550,7 +550,10 @@ public abstract class ArchiveBase<T extends Archive<T>> implements Archive<T>, C
 
         // Now loop through and add all content
         for (final ArchivePath path : from.getContent().keySet()) {
-            to.add(from.get(path).getAsset(), path);
+            Asset asset = from.get(path).getAsset();
+            if (asset != null) {
+                to.add(asset, path);
+            }
         }
 
         // Return

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
@@ -536,7 +536,10 @@ public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase
         final Archive<T> newArchive = factory.create(actualClass, this.getName());
         final Map<ArchivePath, Node> contents = underlyingArchive.getContent();
         for (final ArchivePath path : contents.keySet()) {
-            newArchive.add(contents.get(path).getAsset(), path);
+            Asset asset = contents.get(path).getAsset();
+            if (asset != null) {
+                newArchive.add(asset, path);
+            }
         }
         return newArchive;
     }

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/ArchiveTestBase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/ArchiveTestBase.java
@@ -1397,6 +1397,20 @@ public abstract class ArchiveTestBase<T extends Archive<T>> {
 
         Assert.assertTrue(copyArchive.contains("location"));
     }
+    
+    @Test
+    public void ensureShallowCopyOperatesOnNestedAssets() {
+        Archive<T> archive = getArchive();
+        Asset asset = new ClassLoaderAsset(NAME_TEST_PROPERTIES);
+        archive.add(asset, "location/sublocation");
+
+        Archive<T> copyArchive = archive.shallowCopy();
+
+        Assert.assertTrue(copyArchive.contains("location"));
+        Assert.assertTrue(copyArchive.contains("location/sublocation"));
+        Assert.assertSame(copyArchive.get("location/sublocation").getAsset(), archive.get("location/sublocation")
+            .getAsset());
+    }
 
     @Test
     public void testId() {


### PR DESCRIPTION
ArchiveBase.shallowCopy() and ContainerBase.shallowCopy() now copies
over pointers if there is an asset associated with the path. If no asset
is available in the specified path, the path is omitted from the copy.
This assumes the presence of an asset in a nested path.
