### PR TITLE
[SHRINKWRAP-441] FileStoreTestCase.usedSpace failed under windows due to wrong separator char

### DIFF
--- a/impl-nio2/src/test/java/org/jboss/shrinkwrap/impl/nio/file/FileStoreTestCase.java
+++ b/impl-nio2/src/test/java/org/jboss/shrinkwrap/impl/nio/file/FileStoreTestCase.java
@@ -26,6 +26,7 @@ import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileStoreAttributeView;
 import java.util.logging.Logger;
 
+import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.nio.file.ShrinkWrapFileSystems;
@@ -77,8 +78,7 @@ public class FileStoreTestCase {
         archive.addClass(classToAdd);
 
         // Get size of the class
-        final String pathToClass = new StringBuilder(classToAdd.getName().replace('.', File.separatorChar)).append(
-            ".class").toString();
+        final String pathToClass = classToAdd.getName().replace('.', ArchivePath.SEPARATOR) + ".class";
         final InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(pathToClass);
         long thisClassFileSize = 0L;
         final byte[] buffer = new byte[8 * 1024];


### PR DESCRIPTION
https://issues.jboss.org/browse/SHRINKWRAP-441

Andrew please say if this fix is sufficient or if behaviour of while NIO2 should be altered in order to tolerate both separator characters.
