### PR TITLE
[SHRINKWRAP-445] possibility to export uncompressed Zip archives

### DIFF
--- a/api/src/main/java/org/jboss/shrinkwrap/api/exporter/ZipExporter.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/exporter/ZipExporter.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -25,8 +25,13 @@ import org.jboss.shrinkwrap.api.Assignable;
  * @author <a href="mailto:baileyje@gmail.com">John Bailey</a>
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
  * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+ * @author <a href="mailto:mmatloka@gmail.com">Michal Matloka</a>
  * @version $Revision: $
  */
 public interface ZipExporter extends StreamExporter {
 
+    /**
+     * @return exporter of uncompressed content in ZIP format.
+     */
+    StreamExporter uncompressed();
 }

--- a/api/src/main/java/org/jboss/shrinkwrap/api/exporter/ZipExporter.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/exporter/ZipExporter.java
@@ -31,7 +31,24 @@ import org.jboss.shrinkwrap.api.Assignable;
 public interface ZipExporter extends StreamExporter {
 
     /**
+     * @param enabled
+     *            enable compression of content in ZIP format. True by default.
+     * @return exporter with set given compression setting.
+     */
+    ZipExporter compressionEnabled(boolean enabled);
+
+    /**
+     * @return exporter of compressed content in ZIP format.
+     */
+    ZipExporter compressionEnabled();
+
+    /**
      * @return exporter of uncompressed content in ZIP format.
      */
-    StreamExporter uncompressed();
+    ZipExporter compressionDisabled();
+
+    /**
+     * @return true if compression is enabled.
+     */
+    boolean isCompressionEnabled();
 }

--- a/impl-base/pom.xml
+++ b/impl-base/pom.xml
@@ -63,6 +63,10 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+    </dependency>
   </dependencies>
 
   <!-- Build Configuration -->

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipExporterDelegate.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipExporterDelegate.java
@@ -32,13 +32,13 @@ import org.jboss.shrinkwrap.impl.base.exporter.AbstractExporterDelegate;
  */
 class ZipExporterDelegate extends AbstractExporterDelegate<InputStream> {
 
-    private final boolean uncompressed;
+    private final boolean compressed;
 
     protected ZipExporterDelegate(final Archive<?> archive) {
-        this(archive, false);
+        this(archive, true);
     }
 
-    protected ZipExporterDelegate(final Archive<?> archive, boolean uncompressed) {
+    protected ZipExporterDelegate(final Archive<?> archive, boolean compressed) {
         super(archive);
 
         // Precondition check
@@ -48,7 +48,7 @@ class ZipExporterDelegate extends AbstractExporterDelegate<InputStream> {
                     + archive.toString());
         }
 
-        this.uncompressed = uncompressed;
+        this.compressed = compressed;
     }
 
     @Override
@@ -58,6 +58,6 @@ class ZipExporterDelegate extends AbstractExporterDelegate<InputStream> {
 
     @Override
     protected InputStream getResult() {
-        return new ZipOnDemandInputStream(getArchive(), uncompressed);
+        return new ZipOnDemandInputStream(getArchive(), compressed);
     }
 }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipExporterDelegate.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipExporterDelegate.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -16,14 +16,13 @@
  */
 package org.jboss.shrinkwrap.impl.base.exporter.zip;
 
+import java.io.InputStream;
+import java.util.zip.ZipOutputStream;
+
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.impl.base.exporter.AbstractExporterDelegate;
-
-import java.util.zip.ZipOutputStream;
-
-import java.io.InputStream;
 
 /**
  * Implementation of a ZIP exporter. Cannot handle archives with no content (as there'd be no
@@ -33,7 +32,13 @@ import java.io.InputStream;
  */
 class ZipExporterDelegate extends AbstractExporterDelegate<InputStream> {
 
+    private final boolean uncompressed;
+
     protected ZipExporterDelegate(final Archive<?> archive) {
+        this(archive, false);
+    }
+
+    protected ZipExporterDelegate(final Archive<?> archive, boolean uncompressed) {
         super(archive);
 
         // Precondition check
@@ -42,6 +47,8 @@ class ZipExporterDelegate extends AbstractExporterDelegate<InputStream> {
                 "[SHRINKWRAP-93] Cannot use this JDK-based implementation to export as ZIP an archive with no content: "
                     + archive.toString());
         }
+
+        this.uncompressed = uncompressed;
     }
 
     @Override
@@ -51,6 +58,6 @@ class ZipExporterDelegate extends AbstractExporterDelegate<InputStream> {
 
     @Override
     protected InputStream getResult() {
-        return new ZipOnDemandInputStream(getArchive());
+        return new ZipOnDemandInputStream(getArchive(), uncompressed);
     }
 }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipExporterImpl.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipExporterImpl.java
@@ -34,7 +34,7 @@ import org.jboss.shrinkwrap.impl.base.exporter.AbstractStreamExporterImpl;
  */
 public class ZipExporterImpl extends AbstractStreamExporterImpl implements ZipExporter {
 
-    private boolean uncompressed = false;
+    private boolean compressed = true;
 
     public ZipExporterImpl(final Archive<?> archive) {
         super(archive);
@@ -49,15 +49,30 @@ public class ZipExporterImpl extends AbstractStreamExporterImpl implements ZipEx
     public InputStream exportAsInputStream() {
         // Create export delegate
         final AbstractExporterDelegate<InputStream> exportDelegate = new ZipExporterDelegate(this.getArchive(),
-            uncompressed);
+            compressed);
 
         // Export and get result
         return exportDelegate.export();
     }
 
     @Override
-    public StreamExporter uncompressed() {
-        this.uncompressed = true;
+    public ZipExporter compressionEnabled(final boolean enabled) {
+        this.compressed = enabled;
         return this;
+    }
+
+    @Override
+    public ZipExporter compressionEnabled() {
+        return this.compressionEnabled(true);
+    }
+
+    @Override
+    public ZipExporter compressionDisabled() {
+        return this.compressionEnabled(false);
+    }
+
+    @Override
+    public boolean isCompressionEnabled() {
+        return this.compressed;
     }
 }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipExporterImpl.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipExporterImpl.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -19,6 +19,7 @@ package org.jboss.shrinkwrap.impl.base.exporter.zip;
 import java.io.InputStream;
 
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.exporter.StreamExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.impl.base.exporter.AbstractExporterDelegate;
 import org.jboss.shrinkwrap.impl.base.exporter.AbstractStreamExporterImpl;
@@ -33,6 +34,8 @@ import org.jboss.shrinkwrap.impl.base.exporter.AbstractStreamExporterImpl;
  */
 public class ZipExporterImpl extends AbstractStreamExporterImpl implements ZipExporter {
 
+    private boolean uncompressed = false;
+
     public ZipExporterImpl(final Archive<?> archive) {
         super(archive);
     }
@@ -45,9 +48,16 @@ public class ZipExporterImpl extends AbstractStreamExporterImpl implements ZipEx
     @Override
     public InputStream exportAsInputStream() {
         // Create export delegate
-        final AbstractExporterDelegate<InputStream> exportDelegate = new ZipExporterDelegate(this.getArchive());
+        final AbstractExporterDelegate<InputStream> exportDelegate = new ZipExporterDelegate(this.getArchive(),
+            uncompressed);
 
         // Export and get result
         return exportDelegate.export();
+    }
+
+    @Override
+    public StreamExporter uncompressed() {
+        this.uncompressed = true;
+        return this;
     }
 }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipOnDemandInputStream.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipOnDemandInputStream.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -31,18 +31,31 @@ import org.jboss.shrinkwrap.impl.base.exporter.AbstractOnDemandInputStream;
  */
 class ZipOnDemandInputStream extends AbstractOnDemandInputStream<ZipOutputStream> {
 
+    private final boolean uncompressed;
+
     /**
      * Creates stream directly from archive.
      *
      * @param archive
      */
     ZipOnDemandInputStream(final Archive<?> archive) {
+        this(archive, false);
+    }
+
+    ZipOnDemandInputStream(final Archive<?> archive, boolean uncompressed) {
         super(archive);
+        this.uncompressed = uncompressed;
     }
 
     @Override
     protected ZipOutputStream createOutputStream(final OutputStream outputStream) {
-        return new ZipOutputStream(outputStream);
+        final ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream);
+
+        if (uncompressed) {
+            zipOutputStream.setLevel(ZipOutputStream.STORED);
+        }
+
+        return zipOutputStream;
     }
 
     @Override

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipOnDemandInputStream.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/zip/ZipOnDemandInputStream.java
@@ -31,7 +31,7 @@ import org.jboss.shrinkwrap.impl.base.exporter.AbstractOnDemandInputStream;
  */
 class ZipOnDemandInputStream extends AbstractOnDemandInputStream<ZipOutputStream> {
 
-    private final boolean uncompressed;
+    private final boolean compressed;
 
     /**
      * Creates stream directly from archive.
@@ -39,19 +39,19 @@ class ZipOnDemandInputStream extends AbstractOnDemandInputStream<ZipOutputStream
      * @param archive
      */
     ZipOnDemandInputStream(final Archive<?> archive) {
-        this(archive, false);
+        this(archive, true);
     }
 
-    ZipOnDemandInputStream(final Archive<?> archive, boolean uncompressed) {
+    ZipOnDemandInputStream(final Archive<?> archive, boolean compressed) {
         super(archive);
-        this.uncompressed = uncompressed;
+        this.compressed = compressed;
     }
 
     @Override
     protected ZipOutputStream createOutputStream(final OutputStream outputStream) {
         final ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream);
 
-        if (uncompressed) {
+        if (!compressed) {
             zipOutputStream.setLevel(ZipOutputStream.STORED);
         }
 

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/exporter/ZipExporterTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/exporter/ZipExporterTestCase.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.shrinkwrap.impl.base.exporter;
 
+import static org.mockito.Mockito.mock;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -29,12 +31,12 @@ import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.FileAsset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.StreamExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.base.exporter.zip.ZipExporterImpl;
 import org.jboss.shrinkwrap.impl.base.io.IOUtil;
 import org.jboss.shrinkwrap.impl.base.path.PathUtil;
 import org.junit.Assert;
@@ -206,7 +208,7 @@ public final class ZipExporterTestCase extends StreamExporterTestBase<ZipImporte
         final Archive<?> archive = createArchiveWithAssets();
 
         // Export as InputStream
-        final InputStream exportStream = archive.as(ZipExporter.class).uncompressed().exportAsInputStream();
+        final InputStream exportStream = archive.as(ZipExporter.class).compressionDisabled().exportAsInputStream();
 
         // Validate
         final File tempDirectory = createTempDirectory("testUncompressedExport");
@@ -236,13 +238,75 @@ public final class ZipExporterTestCase extends StreamExporterTestBase<ZipImporte
             "/WEB-INF/lib/hsqldb.jar");
 
         // when
-        webArchive.as(ZipExporter.class).uncompressed().exportTo(file1, true);
+        webArchive.as(ZipExporter.class).compressionDisabled().exportTo(file1, true);
         final WebArchive webArchive2 = ShrinkWrap.createFromZipFile(WebArchive.class, file1);
         webArchive2.as(ZipExporter.class).exportTo(file2, true);
 
         // then check sizes
         Assert.assertEquals(uncompressedArchiveSize, file1.length());
         Assert.assertEquals(compressedArchiveSize, file2.length());
+    }
+
+    /**
+     * Method level test for compression enabling method
+     */
+    @Test
+    public void testCompressionEnabledByArgument() {
+        // given
+        final Archive<?> archive = mock(Archive.class);
+        final boolean compression = true;
+
+        // when
+        final ZipExporter zipExporter = new ZipExporterImpl(archive).compressionEnabled(compression);
+
+        // then
+        Assert.assertEquals(compression, zipExporter.isCompressionEnabled());
+    }
+
+    /**
+     * Method level test for compression enabling method
+     */
+    @Test
+    public void testCompressionEnabled() {
+        // given
+        final Archive<?> archive = mock(Archive.class);
+
+        // when
+        final ZipExporter zipExporter = new ZipExporterImpl(archive).compressionEnabled();
+
+        // then
+        Assert.assertEquals(true, zipExporter.isCompressionEnabled());
+    }
+
+    /**
+     * Method level test for compression enabling method
+     */
+    @Test
+    public void testCompressionDisabled() {
+        // given
+        final Archive<?> archive = mock(Archive.class);
+
+        // when
+        final ZipExporter zipExporter = new ZipExporterImpl(archive).compressionDisabled();
+
+        // then
+        Assert.assertEquals(false, zipExporter.isCompressionEnabled());
+    }
+
+    /**
+     * Method level test for compression enabling method
+     */
+    @Test
+    public void testCompressionDisabledByArgument() {
+        // given
+        final Archive<?> archive = mock(Archive.class);
+        final boolean compression = false;
+
+        // when
+        final ZipExporter zipExporter = new ZipExporterImpl(archive).compressionEnabled(compression);
+
+        // then
+        Assert.assertEquals(compression, zipExporter.isCompressionEnabled());
     }
 
     // -------------------------------------------------------------------------------------||

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 
     <!-- Versioning -->
     <version.junit_junit>4.8.2</version.junit_junit>
+    <version.mockito>1.9.5</version.mockito>
     <version.org.apache.maven.plugins_maven-site-plugin>3.0-beta-3</version.org.apache.maven.plugins_maven-site-plugin>
 
   </properties>
@@ -241,6 +242,12 @@
         <scope>test</scope>
       </dependency>
 
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <version>${version.mockito}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/SHRINKWRAP-445

Usage

```
archive.as(ZipExporter.class).uncompressed().exportAsInputStream();
```
