### PR TITLE
[SHRINKWRAP-450] Compiler plugin configuration fix - build do not working due to lack of JAVA7_HOME environment variable

### DIFF
--- a/impl-nio2/pom.xml
+++ b/impl-nio2/pom.xml
@@ -74,8 +74,6 @@
             <source>1.7</source>
             <target>1.7</target>
           </compilerArguments>
-          <argLine>-Xmx512M</argLine>
-          <executable>${env.JAVA7_HOME}/bin/javac</executable>
         </configuration>
       </plugin>
       

--- a/pom.xml
+++ b/pom.xml
@@ -162,8 +162,6 @@
             <source>1.5</source>
             <target>1.5</target>
           </compilerArguments>
-          <argLine>-Xmx512M</argLine>
-          <executable>${JAVA_HOME}/bin/javac</executable>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/SHRINKWRAP-450
