### PR TITLE
[SHRINKWRAP-461] SeekableInMemoryByteChannel returns incorrect value for EOF

### DIFF
--- a/api-nio2/src/main/java/org/jboss/shrinkwrap/api/nio/file/SeekableInMemoryByteChannel.java
+++ b/api-nio2/src/main/java/org/jboss/shrinkwrap/api/nio/file/SeekableInMemoryByteChannel.java
@@ -104,8 +104,8 @@ public class SeekableInMemoryByteChannel implements SeekableByteChannel {
             numBytesRemainingInContent = this.contents.length - this.position;
 
             // Set position was greater than the size? Just return.
-            if (numBytesRemainingInContent < 0) {
-                return 0;
+            if (numBytesRemainingInContent <= 0) {
+                return -1;
             }
 
             // We'll read in either the number of bytes remaining in content or the amount of space in the buffer,

--- a/api-nio2/src/test/java/org/jboss/shrinkwrap/api/nio/file/SeekableInMemoryByteChannelTestCase.java
+++ b/api-nio2/src/test/java/org/jboss/shrinkwrap/api/nio/file/SeekableInMemoryByteChannelTestCase.java
@@ -152,7 +152,7 @@ public class SeekableInMemoryByteChannelTestCase {
         this.channel.write(smallerBuffer);
         // Read a byte from a position past the size
         final int numBytesRead = this.channel.position(this.channel.size() + 3).read(ByteBuffer.wrap(new byte[1]));
-        Assert.assertEquals("Read on position > size should report 0 bytes read", 0, numBytesRead);
+        Assert.assertEquals("Read on position > size should return -1", -1, numBytesRead);
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/SHRINKWRAP-461

Bug fix for SeekableInMemoryByteChannel to return -1 rather than 0 when at (or beyond) the end of data. This brings it in line with the API for SeekableByteChannel.
