### PR TITLE
SHRINKWRAP-463

### DIFF
--- a/impl-nio2/src/main/java/org/jboss/shrinkwrap/impl/nio/file/ShrinkWrapFileChannel.java
+++ b/impl-nio2/src/main/java/org/jboss/shrinkwrap/impl/nio/file/ShrinkWrapFileChannel.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.shrinkwrap.api.nio.file;
+package org.jboss.shrinkwrap.impl.nio.file;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -32,11 +32,11 @@ import java.nio.channels.WritableByteChannel;
  *
  * @author <a href="mailto:ts@bee.kz">Tair Sabirgaliev</a>
  */
-public class InMemoryFileChannel extends FileChannel {
+public class ShrinkWrapFileChannel extends FileChannel {
 
     SeekableByteChannel delegate;
 
-    public InMemoryFileChannel(SeekableByteChannel delegate) {
+    public ShrinkWrapFileChannel(SeekableByteChannel delegate) {
         this.delegate = delegate;
     }
 

--- a/impl-nio2/src/main/java/org/jboss/shrinkwrap/impl/nio/file/ShrinkWrapFileSystemProvider.java
+++ b/impl-nio2/src/main/java/org/jboss/shrinkwrap/impl/nio/file/ShrinkWrapFileSystemProvider.java
@@ -55,7 +55,6 @@ import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.asset.Asset;
-import org.jboss.shrinkwrap.api.nio.file.InMemoryFileChannel;
 import org.jboss.shrinkwrap.api.nio.file.MemoryNamedAsset;
 import org.jboss.shrinkwrap.api.nio.file.SeekableInMemoryByteChannel;
 
@@ -246,7 +245,7 @@ public class ShrinkWrapFileSystemProvider extends FileSystemProvider {
     @Override
     public FileChannel newFileChannel(Path path, Set<? extends OpenOption> options,
             FileAttribute<?>... attrs) throws IOException {
-        return new InMemoryFileChannel(newByteChannel(path, options, attrs));
+        return new ShrinkWrapFileChannel(newByteChannel(path, options, attrs));
     }
 
     /**


### PR DESCRIPTION
- `ShrinkWrapFileSystemProvider.newFileChannel()` is backed by `InMemoryFileChannel` which delegates all equivalent operations to `SeekableInMemoryByteChannel`. 
- Other operations on `InMemoryFileChannel` for now throw `UnsupportedOperationException`
