### PR TITLE
[SHRINKWRAP-468] Fix for Archive.move() when directory have children

### DIFF
--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/ArchiveBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/ArchiveBase.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -615,6 +616,15 @@ public abstract class ArchiveBase<T extends Archive<T>> implements Archive<T>, C
         } else {
             add(asset, target);
         }
+
+        // move children
+        final Set<Node> nodeToMoveChildren = nodeToMove.getChildren();
+        for (final Node child : nodeToMoveChildren) {
+            final String childName = child.getPath().get().replaceFirst(child.getPath().getParent().get(), "");
+            final ArchivePath childTargetPath = ArchivePaths.create(target, childName);
+            move(child.getPath(), childTargetPath);
+        }
+
         delete(source);
 
         return covariantReturn();

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/ArchiveTestBase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/ArchiveTestBase.java
@@ -1386,6 +1386,30 @@ public abstract class ArchiveTestBase<T extends Archive<T>> {
         Assert.assertTrue("Directory should be at the new path", archive.get(targetPath).getAsset() == null);
     }
 
+    @Test
+    public void shouldMoveNotEmptyDirectory() {
+        final Archive<JavaArchive> archive = ShrinkWrap.create(JavaArchive.class, "archive.jar");
+        final String sourcePath = "path1";
+        final String targetPath = "path2";
+
+        final String childDirName = "childDir";
+        final String childDirPath = sourcePath + "/" + childDirName;
+        final String childDirTargetPath = targetPath + "/" + childDirName;
+
+        final String childFileName = "file1";
+        final String childFilePath = childDirPath + "/" + childFileName;
+        final String childFileTargetPath = childDirTargetPath + "/" + childFileName;
+
+        archive.addAsDirectory(sourcePath);
+        archive.addAsDirectory(childDirName);
+        archive.add(EmptyAsset.INSTANCE, childFilePath);
+        archive.move(sourcePath, targetPath);
+
+        Assert.assertTrue("Directory should be at the new path", archive.get(targetPath).getAsset() == null);
+        Assert.assertTrue("Child dir should be at the new path", archive.get(childDirTargetPath).getAsset() == null);
+        Assert.assertTrue("Child asset should be at the new path", archive.get(childFileTargetPath).getAsset() != null);
+    }
+
     @Test(expected = IllegalArchivePathException.class)
     public void shouldNotMoveAssetBecauseOfInexistentPath() {
        final Archive<JavaArchive> archive = ShrinkWrap.create(JavaArchive.class, "archive.jar");


### PR DESCRIPTION
https://issues.jboss.org/browse/SHRINKWRAP-468
