### PR TITLE
[SHRINKWRAP-470] Fix for SeekableInMemoryByteChannel.truncate misimplementing the contract

### DIFF
--- a/api-nio2/src/main/java/org/jboss/shrinkwrap/api/nio/file/SeekableInMemoryByteChannel.java
+++ b/api-nio2/src/main/java/org/jboss/shrinkwrap/api/nio/file/SeekableInMemoryByteChannel.java
@@ -255,11 +255,11 @@ public class SeekableInMemoryByteChannel implements SeekableByteChannel {
                 // Set the new array as our contents
                 this.contents = newContents;
             }
-            // If we've been given a size greater than we are
-            if (newSize > currentSize) {
-                // Reset the position only
-                this.position = newSize;
-            }
+
+            // If we've been given a size greater than or equal to us then do nothing
+            // if (newSize >= currentSize) {
+            // // do nothing
+            // }
         }
 
         // Return this reference

--- a/api-nio2/src/test/java/org/jboss/shrinkwrap/api/nio/file/SeekableInMemoryByteChannelTestCase.java
+++ b/api-nio2/src/test/java/org/jboss/shrinkwrap/api/nio/file/SeekableInMemoryByteChannelTestCase.java
@@ -241,7 +241,7 @@ public class SeekableInMemoryByteChannelTestCase {
         Assert.assertEquals("Channel should report unchanged size after truncate to bigger value", oldSize,
             this.channel.size());
         // Correct position, beyond size?
-        Assert.assertEquals("Channel should report adjusted position after truncate to bigger value", newSize,
+        Assert.assertEquals("Channel should report unchanged position after truncate to bigger value", oldSize,
             this.channel.position());
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/SHRINKWRAP-470
