### PR TITLE
Add support for setBeansXml() on WebContainers, ResourceAdapterContainer...

### DIFF
--- a/api/src/main/java/org/jboss/shrinkwrap/api/container/CDIBeanContainer.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/container/CDIBeanContainer.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shrinkwrap.api.container;
+
+import java.io.File;
+import java.net.URL;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.Asset;
+
+/**
+ * Defines the contract for a component capable of storing CDI bean descriptors, i.e. a beans.xml. <br/>
+ * <br/>
+ * The actual path to the resources within the {@link Archive} is up to the implementations/specifications.
+ *
+ * @author <a href="mailto:robert.panzer@me.com">Robert Panzer</a>
+ * @version $Revision: $
+ */
+public interface CDIBeanContainer<T extends Archive<T>> {
+
+    /**
+     * Adds an empty beans.xml to this {@link Archive}.
+     *
+     * @return This virtual archive
+     */
+    T setBeansXML();
+
+    /**
+     * Adds a resource to this {@link Archive} as beans.xml. <br/>
+     * <br/>
+     * The {@link ClassLoader} used to obtain the resource is up to the implementation. <br/>
+     * For instance a resourceName of "test/example.xml" could be placed in "/META-INF/beans.xml"
+     * or "/WEB-INF/beans.xml".
+     *
+     * @param resourceName
+     *            Name of the {@link ClassLoader} resource to add
+     * @return This virtual archive
+     * @throws IllegalArgumentException
+     *             if resourceName is null
+     * @see #setBeansXML(Asset)
+     */
+    T setBeansXML(String resourceName);
+
+    /**
+     * Adds a {@link File} to this {@link Archive} as beans.xml. <br/>
+     * <br/>
+     * For instance a {@link File} "test/example.xml" could be placed in "/META-INF/beans.xml"
+     * or "/WEB-INF/beans.xml".
+     *
+     * @param resource
+     *            {@link File} resource to add
+     * @return This virtual archive
+     * @throws IllegalArgumentException
+     *             if resource is null
+     * @see #setBeansXML(Asset)
+     */
+    T setBeansXML(File resource);
+
+    /**
+     * Adds a {@link URL} to this {@link Archive} as beans.xml. <br/>
+     * <br/>
+     * For instance a {@link URL} "http://my.com/example.xml" could be placed in "/META-INF/beans.xml"
+     * or "/WEB-INF/beans.xml"
+     *
+     * @param resource
+     *            {@link URL} resource to add
+     * @return This virtual archive
+     * @throws IllegalArgumentException
+     *             if resource is null
+     * @see #setBeansXML(Asset)
+     */
+    T setBeansXML(URL resource);
+
+    /**
+     * Adds a {@link Asset} to this {@link Archive} as beans.xml.
+     *
+     * @param asset
+     *            {@link Asset} resource to add
+     * @return This virtual archive
+     * @throws IllegalArgumentException
+     *             if resource is null
+     */
+    T setBeansXML(Asset asset);
+}

--- a/api/src/main/java/org/jboss/shrinkwrap/api/container/ResourceAdapterContainer.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/container/ResourceAdapterContainer.java
@@ -31,7 +31,7 @@ import org.jboss.shrinkwrap.api.asset.Asset;
  * @version $Revision: $
  * @param <T>
  */
-public interface ResourceAdapterContainer<T extends Archive<T>> {
+public interface ResourceAdapterContainer<T extends Archive<T>> extends CDIBeanContainer<T> {
     /**
      * Adds the resource as ra.xml to the container, returning the container itself. <br/>
      * The {@link ClassLoader} used to obtain the resource is up to the implementation.

--- a/api/src/main/java/org/jboss/shrinkwrap/api/container/WebContainer.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/container/WebContainer.java
@@ -32,7 +32,7 @@ import org.jboss.shrinkwrap.api.asset.Asset;
  * @version $Revision: $
  * @param <T>
  */
-public interface WebContainer<T extends Archive<T>> {
+public interface WebContainer<T extends Archive<T>> extends CDIBeanContainer<T> {
     // -------------------------------------------------------------------------------------||
     // Contracts --------------------------------------------------------------------------||
     // -------------------------------------------------------------------------------------||

--- a/api/src/main/java/org/jboss/shrinkwrap/api/spec/JavaArchive.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/spec/JavaArchive.java
@@ -17,6 +17,7 @@
 package org.jboss.shrinkwrap.api.spec;
 
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.container.CDIBeanContainer;
 import org.jboss.shrinkwrap.api.container.ServiceProviderContainer;
 
 /**
@@ -27,5 +28,5 @@ import org.jboss.shrinkwrap.api.container.ServiceProviderContainer;
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
  * @version $Revision: $
  */
-public interface JavaArchive extends Archive<JavaArchive>, ServiceProviderContainer<JavaArchive> {
+public interface JavaArchive extends Archive<JavaArchive>, ServiceProviderContainer<JavaArchive>, CDIBeanContainer<JavaArchive> {
 }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
@@ -46,9 +46,11 @@ import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.asset.ClassAsset;
 import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.asset.NamedAsset;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
+import org.jboss.shrinkwrap.api.container.CDIBeanContainer;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.container.ManifestContainer;
@@ -57,6 +59,7 @@ import org.jboss.shrinkwrap.api.container.ServiceProviderContainer;
 import org.jboss.shrinkwrap.api.exporter.StreamExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.formatter.Formatter;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.jboss.shrinkwrap.impl.base.ArchiveBase;
 import org.jboss.shrinkwrap.impl.base.AssignableBase;
 import org.jboss.shrinkwrap.impl.base.URLPackageScanner;
@@ -79,7 +82,7 @@ import org.jboss.shrinkwrap.spi.Configurable;
  */
 public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase<Archive<?>> implements Archive<T>,
     ManifestContainer<T>, ServiceProviderContainer<T>, ResourceContainer<T>, ClassContainer<T>, LibraryContainer<T>,
-    ArchiveFormatAssociable {
+    CDIBeanContainer<T>, ArchiveFormatAssociable {
     // -------------------------------------------------------------------------------------||
     // Class Members ----------------------------------------------------------------------||
     // -------------------------------------------------------------------------------------||
@@ -1995,4 +1998,31 @@ public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase
 
         return cls;
     }
+
+    @Override
+    public T setBeansXML() {
+        return setBeansXML(EmptyAsset.INSTANCE);
+    }
+
+    @Override
+    public T setBeansXML(File resource) throws IllegalArgumentException {
+        return setBeansXML(new FileAsset(resource));
+    }
+
+    @Override
+    public T setBeansXML(String resourceName) throws IllegalArgumentException {
+        return setBeansXML(new ClassLoaderAsset(resourceName));
+    }
+
+    @Override
+    public T setBeansXML(URL resource) throws IllegalArgumentException {
+        return setBeansXML(new UrlAsset(resource));
+    }
+
+    @Override
+    public T setBeansXML(Asset resource) throws IllegalArgumentException {
+        Validate.notNull(resource, "Resource should be specified");
+        return addAsManifestResource(resource, ArchivePaths.create("beans.xml"));
+    }
+
 }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/WebContainerBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/WebContainerBase.java
@@ -24,6 +24,7 @@ import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 import org.jboss.shrinkwrap.api.container.WebContainer;
@@ -592,4 +593,31 @@ public abstract class WebContainerBase<T extends Archive<T>> extends ContainerBa
         addClass(serviceInterface);
         return addClasses(serviceImpls);
     }
+
+    @Override
+    public T setBeansXML() {
+        return setBeansXML(EmptyAsset.INSTANCE);
+    }
+
+    @Override
+    public T setBeansXML(File resource) throws IllegalArgumentException {
+        return setBeansXML(new FileAsset(resource));
+    }
+
+    @Override
+    public T setBeansXML(String resourceName) throws IllegalArgumentException {
+        return setBeansXML(new ClassLoaderAsset(resourceName));
+    }
+
+    @Override
+    public T setBeansXML(URL resource) throws IllegalArgumentException {
+        return setBeansXML(new UrlAsset(resource));
+    }
+
+    @Override
+    public T setBeansXML(Asset resource) throws IllegalArgumentException {
+        Validate.notNull(resource, "Resource should be specified");
+        return addAsWebInfResource(resource, ArchivePaths.create("beans.xml"));
+    }
+
 }

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/EnterpriseArchiveImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/EnterpriseArchiveImplTestCase.java
@@ -19,6 +19,7 @@ package org.jboss.shrinkwrap.impl.base.spec;
 import org.jboss.shrinkwrap.api.ArchiveFormat;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.container.CDIBeanContainer;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.EnterpriseContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
@@ -118,6 +119,11 @@ public class EnterpriseArchiveImplTestCase extends DynamicEnterpriseContainerTes
     }
 
     @Override
+    protected CDIBeanContainer<EnterpriseArchive> getCDIBeanArchiveContainer() {
+        throw new UnsupportedOperationException("EnterpriseArchives do not support CDI bean containers");
+    }
+
+    @Override
     protected ArchivePath getManifestPath() {
         return PATH_APPLICATION;
     }
@@ -130,6 +136,11 @@ public class EnterpriseArchiveImplTestCase extends DynamicEnterpriseContainerTes
     @Override
     protected ArchivePath getLibraryPath() {
         return PATH_LIBRARY;
+    }
+
+    @Override
+    protected ArchivePath getBeansXmlPath() {
+        throw new UnsupportedOperationException("EnterpriseArchives do not support CDI bean containers");
     }
 
     @Override

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/GenericArchiveImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/GenericArchiveImplTestCase.java
@@ -20,6 +20,7 @@ import org.jboss.shrinkwrap.api.ArchiveFormat;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.GenericArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.container.CDIBeanContainer;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.container.ManifestContainer;
@@ -120,6 +121,11 @@ public class GenericArchiveImplTestCase extends DynamicContainerTestBase<Generic
     }
 
     @Override
+    protected CDIBeanContainer<GenericArchive> getCDIBeanArchiveContainer() {
+        throw UNSUPPORTED;
+    }
+
+    @Override
     protected ArchivePath getManifestPath() {
         throw UNSUPPORTED;
     }
@@ -136,6 +142,11 @@ public class GenericArchiveImplTestCase extends DynamicContainerTestBase<Generic
 
     @Override
     protected ArchivePath getLibraryPath() {
+        throw UNSUPPORTED;
+    }
+
+    @Override
+    protected ArchivePath getBeansXmlPath() {
         throw UNSUPPORTED;
     }
 

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/JavaArchiveImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/JavaArchiveImplTestCase.java
@@ -19,6 +19,7 @@ package org.jboss.shrinkwrap.impl.base.spec;
 import org.jboss.shrinkwrap.api.ArchiveFormat;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.container.CDIBeanContainer;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.container.ManifestContainer;
@@ -119,6 +120,11 @@ public class JavaArchiveImplTestCase extends DynamicContainerTestBase<JavaArchiv
     }
 
     @Override
+    protected CDIBeanContainer<JavaArchive> getCDIBeanArchiveContainer() {
+        return getArchive();
+    }
+
+    @Override
     protected ArchivePath getManifestPath() {
         return PATH_MANIFEST;
     }
@@ -138,9 +144,14 @@ public class JavaArchiveImplTestCase extends DynamicContainerTestBase<JavaArchiv
         throw new UnsupportedOperationException("JavaArchive does not support libraries");
     }
 
+
     @Override
     protected ArchiveFormat getExpectedArchiveFormat() {
         return ArchiveFormat.ZIP;
     }
 
+    @Override
+    protected ArchivePath getBeansXmlPath() {
+        return PATH_MANIFEST;
+    }
 }

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/ResourceAdapterArchiveImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/ResourceAdapterArchiveImplTestCase.java
@@ -19,6 +19,7 @@ package org.jboss.shrinkwrap.impl.base.spec;
 import org.jboss.shrinkwrap.api.ArchiveFormat;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.container.CDIBeanContainer;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.container.ManifestContainer;
@@ -119,6 +120,11 @@ public class ResourceAdapterArchiveImplTestCase extends DynamicResourceAdapterCo
     }
 
     @Override
+    protected CDIBeanContainer<ResourceAdapterArchive> getCDIBeanArchiveContainer() {
+        return getArchive();
+    }
+
+    @Override
     protected ArchivePath getManifestPath() {
         return PATH_MANIFEST;
     }
@@ -142,7 +148,12 @@ public class ResourceAdapterArchiveImplTestCase extends DynamicResourceAdapterCo
     protected ResourceContainer<ResourceAdapterArchive> getResourceContainer() {
         return getArchive();
     }
-
+    
+    @Override
+    protected ArchivePath getBeansXmlPath() {
+        return PATH_MANIFEST;
+    }
+    
     // -------------------------------------------------------------------------------------||
     // Required Impls - DynamicResourceAdapterContainerTestBase ---------------------------||
     // -------------------------------------------------------------------------------------||

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/WebArchiveImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/WebArchiveImplTestCase.java
@@ -20,6 +20,7 @@ import org.jboss.shrinkwrap.api.ArchiveFormat;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.container.CDIBeanContainer;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.container.ManifestContainer;
@@ -127,6 +128,11 @@ public class WebArchiveImplTestCase extends DynamicWebContainerTestBase<WebArchi
     }
 
     @Override
+    protected CDIBeanContainer<WebArchive> getCDIBeanArchiveContainer() {
+        return getArchive();
+    }
+
+    @Override
     protected ArchivePath getManifestPath() {
         return PATH_MANIFEST;
     }
@@ -144,6 +150,11 @@ public class WebArchiveImplTestCase extends DynamicWebContainerTestBase<WebArchi
     @Override
     protected ArchivePath getLibraryPath() {
         return PATH_LIBRARY;
+    }
+
+    @Override
+    protected ArchivePath getBeansXmlPath() {
+        return PATH_WEBINF;
     }
 
     // -------------------------------------------------------------------------------------||

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/DynamicContainerTestBase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/DynamicContainerTestBase.java
@@ -49,6 +49,7 @@ import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.container.CDIBeanContainer;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.container.ManifestContainer;
@@ -107,6 +108,10 @@ public abstract class DynamicContainerTestBase<T extends Archive<T>> extends Arc
     protected abstract ArchivePath getLibraryPath();
 
     protected abstract LibraryContainer<T> getLibraryContainer();
+
+    protected abstract CDIBeanContainer<T> getCDIBeanArchiveContainer();
+
+    protected abstract ArchivePath getBeansXmlPath();
 
     protected URL getURLForClassResource(String name) {
         return SecurityActions.getThreadContextClassLoader().getResource(name);
@@ -1998,6 +2003,16 @@ public abstract class DynamicContainerTestBase<T extends Archive<T>> extends Arc
         Assert.assertFalse(archive.contains(ArchivePaths.create(file)));
     }
 
+    @Test
+    @ArchiveType(CDIBeanContainer.class)
+    public void testSetBeansXmlPath() throws Exception {
+        getCDIBeanArchiveContainer().setBeansXML();
+
+        ArchivePath expectedPath = new BasicPath(getBeansXmlPath(), "beans.xml");
+        Assert.assertTrue("Archive should contain " + expectedPath, getArchive().contains(expectedPath));
+    }
+
+    
     private void assertNotContainsClass(ArchivePath notExpectedPath) {
         Assert.assertFalse("Located unexpected class at " + notExpectedPath.get(),
             getArchive().contains(notExpectedPath));


### PR DESCRIPTION
...s and JavaArchives

@ALRubinger: I created this following our discussion yesterday.
I don't know if I got your idea right. If not maybe you could give me hint how it could be done better.

What I am unsure of is that
1. ContainerBase already implements the setBeansXML methods, also for EnterpriseContainers. Nevertheless they are not offered by the EnterpriseArchive interface.
2. WebContainerBase overloads the implementation of ContainerBase instead of having the implementations side-by-side in the hierarchy. (Unsure what approach is better.)
