### PR TITLE
Added support for TargetArchiveAwareAssets and automatically arranging d...

### DIFF
--- a/api/src/main/java/org/jboss/shrinkwrap/api/Archive.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/Archive.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.NamedAsset;
+import org.jboss.shrinkwrap.api.asset.TargetArchiveAwareAsset;
 import org.jboss.shrinkwrap.api.exporter.StreamExporter;
 import org.jboss.shrinkwrap.api.formatter.Formatter;
 import org.jboss.shrinkwrap.api.formatter.Formatters;
@@ -138,6 +139,22 @@ public interface Archive<T extends Archive<T>> extends Assignable {
      *             If the target is invalid.
      */
     T add(Asset asset, String target) throws IllegalArgumentException;
+
+    /**
+     * Adds the specified resource under the context determined by
+     * the asset itself dependending on the archive.
+     * <p>That means that a beans.xml should automatically get sorted
+     * into META-INF for JavaArchives and into WEB-INF for WebArchives.
+     *
+     * @param asset
+     * @return
+     * @throws IllegalArgumentException
+     *             If asset is not specified or a target archive path
+     *             cannot be determined.
+     * @throws IllegalArchivePathException
+     *             If the target is invalid.
+     */
+    T add(TargetArchiveAwareAsset asset) throws IllegalArgumentException;
 
     /**
      * Adds the specified directory.

--- a/api/src/main/java/org/jboss/shrinkwrap/api/asset/DescriptiveAsset.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/asset/DescriptiveAsset.java
@@ -1,0 +1,112 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.shrinkwrap.api.asset;
+
+import java.io.InputStream;
+import java.io.File;
+import java.net.URL;
+
+/**
+ * A descriptive asset contains descriptors that are available from the file system,
+ * class loader or some URL and can be automatically added to an archive at the
+ * correct location. So a DescriptiveAsset having the name beans.xml will be
+ * added at WEB-INF for a WebArchive and META-INF for a JavaArchive.
+ * <p>A DescriptiveAsset wraps an {@link EmptyAsset} a {@link FileAsset}
+ * a {@link StringAsset} or a {@link UrlAsset} or some other arbitrary asset.
+ * <p>Examples:
+ * <ul>
+ * <li>Adding an empty beans.xml to a jar so that the jar eventually contains
+ * META-INF/beans.xml:
+ * <code><pre>
+ * ShrinkWrap.create(JavaArchive.class).add(new DescriptiveAsset("beans.xml"));
+ * </pre></code>
+ * <li>Adding an empty beans.xml to a war so that the war eventually contains
+ * WEB-INF/beans.xml:
+ * <code><pre>
+ * ShrinkWrap.create(WebArchive.class).add(new DescriptiveAsset("beans.xml"));
+ * </pre></code>
+ * </ul>
+ *
+ * @author <a href="mailto:robert.panzer@me.com">Robert Panzer</a>
+ */
+public class DescriptiveAsset implements TargetArchiveAwareAsset {
+
+    private String name;
+
+    private Asset wrappedAsset;
+
+    /**
+     * Creates a new asset with an empty content.
+     * @param name The name of the asset, e.g. beans.xml
+     * @see EmptyAsset
+     */
+    public DescriptiveAsset(String name) {
+        this(name, EmptyAsset.INSTANCE);
+    }
+
+    /**
+     * Creates a new asset using the content of the specified file.
+     * @param name The name of the asset, e.g. beans.xml
+     * @param file The file of which the content should be used.
+     * @see FileAsset
+     */
+    public DescriptiveAsset(String name, File file) {
+        this(name, new FileAsset(file));
+    }
+
+    /**
+     * Creates a new asset using the specified plain text content.
+     * @param name The name of the asset, e.g. beans.xml
+     * @param content The plain text content of this asset
+     * @see StringAsset
+     */
+    public DescriptiveAsset(String name, String content) {
+        this(name, new StringAsset(content));
+    }
+
+    /**
+     * Creates a new asset using the content obtained from the specified URL.
+     * @param name The name of the asset, e.g. beans.xml
+     * @param url The URL that backs the content of this asset
+     * @see UrlAsset
+     */
+    public DescriptiveAsset(String name, URL url) {
+        this(name, new UrlAsset(url));
+    }
+
+    /**
+     * Creates a new asset using the content of the specified asset.
+     * @param name The name of the asset, e.g. beans.xml
+     * @param asset The asset that backs the content of this asset.
+     * @see UrlAsset
+     */
+    public DescriptiveAsset(String name, Asset asset) {
+        this.name = name;
+        this.wrappedAsset = asset;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public InputStream openStream() {
+        return wrappedAsset.openStream();
+    }
+
+}

--- a/api/src/main/java/org/jboss/shrinkwrap/api/asset/TargetArchiveAwareAsset.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/asset/TargetArchiveAwareAsset.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.shrinkwrap.api.asset;
+
+/**
+ * A target archive aware asset can be automatically added to an archive at
+ * the correct path. That means that a TargetArchiveAwareAsset having the name
+ * beans.xml will automatically be added at the path WEB-INF/ for web archives
+ * and META-INF/ for java or resoure adapter archives.
+ *
+ * @author <a href="mailto:robert.panzer@me.com">Robert Panzer</a>
+ */
+public interface TargetArchiveAwareAsset extends NamedAsset {
+
+}

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/MemoryMapArchiveBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/MemoryMapArchiveBase.java
@@ -40,7 +40,9 @@ import org.jboss.shrinkwrap.api.IllegalOverwriteException;
 import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
 import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.TargetArchiveAwareAsset;
 import org.jboss.shrinkwrap.api.exporter.StreamExporter;
+import org.jboss.shrinkwrap.impl.base.asset.AssetUtil;
 import org.jboss.shrinkwrap.impl.base.path.BasicPath;
 import org.jboss.shrinkwrap.impl.base.path.PathUtil;
 
@@ -126,6 +128,22 @@ public abstract class MemoryMapArchiveBase<T extends Archive<T>> extends Archive
         Validate.notNull(path, "No path was specified");
 
         return addAsset(path, asset);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.jboss.shrinkwrap.api.Archive#add(org.jboss.shrinkwrap.api.asset.TargetArchiveAwareAsset)
+     */
+    @Override
+    public T add(TargetArchiveAwareAsset asset) {
+        Validate.notNull(asset, "No asset was specified");
+
+        Node node = AssetUtil.arrangeAsset(asset, this);
+
+        addNewNode(node.getPath(), node.getAsset());
+
+        return covariantReturn();
     }
 
     /**

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/asset/DefaultAssetArranger.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/asset/DefaultAssetArranger.java
@@ -1,0 +1,116 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.shrinkwrap.impl.base.asset;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.TargetArchiveAwareAsset;
+import org.jboss.shrinkwrap.impl.base.NodeImpl;
+import org.jboss.shrinkwrap.spi.TargetArchiveAwareAssetArranger;
+
+/**
+ * Default implementation of {@link TargetArchiveAwareAssetArranger} that knows
+ * to arrange the default Java EE descriptors.
+ *
+ * @author <a href="mailto:robert.panzer@me.com">Robert Panzer</a>
+ */
+public class DefaultAssetArranger implements TargetArchiveAwareAssetArranger {
+
+    private static final String META_INF = "META-INF";
+
+    private static final String WEB_INF  = "WEB-INF";
+
+    @Override
+    public Node arrange(TargetArchiveAwareAsset asset, Archive<?> archive) {
+
+        if (archive.getName().endsWith(".war")) {
+            return arrangeWarDescriptors(asset);
+        } else if (archive.getName().endsWith(".rar")) {
+            return arrangeRarDescriptors(asset);
+        } else if (archive.getName().endsWith(".jar")) {
+            return arrangeJarDescriptors(asset);
+        } else if (archive.getName().endsWith(".ear")) {
+            return arrangeEarDescriptors(asset);
+        }
+        return null;
+
+    }
+
+    private static final Collection<String> WAR_WEB_INF_DESCRIPTORS =
+            Arrays.asList(
+                "web.xml",
+                "ejb-jar.xml",
+                "faces-config.xml",
+                "beans.xml");
+
+    private static final Collection<String> WAR_META_INF_DESCRIPTORS =
+            Arrays.asList(
+                "MANIFEST.MF");
+
+    private Node arrangeWarDescriptors(TargetArchiveAwareAsset asset) {
+        if (WAR_WEB_INF_DESCRIPTORS.contains(asset.getName())) {
+            return new NodeImpl(ArchivePaths.create(WEB_INF, asset.getName()), asset);
+        } else if (WAR_META_INF_DESCRIPTORS.contains(asset.getName())) {
+            return new NodeImpl(ArchivePaths.create(META_INF, asset.getName()), asset);
+        }
+        return null;
+    }
+
+    private static final Collection<String> RAR_META_INF_DESCRIPTORS =
+            Arrays.asList(
+                "ra.xml",
+                "beans.xml",
+                "MANIFEST.MF");
+
+    private Node arrangeRarDescriptors(TargetArchiveAwareAsset asset) {
+        if (RAR_META_INF_DESCRIPTORS.contains(asset.getName())) {
+            return new NodeImpl(ArchivePaths.create(META_INF, asset.getName()), asset);
+        }
+        return null;
+    }
+
+    private static final Collection<String> JAR_META_INF_DESCRIPTORS =
+            Arrays.asList(
+                "ejb-jar.xml",
+                "ra.xml",
+                "web-fragment.xml",
+                "faces-config.xml",
+                "MANIFEST.MF");
+
+    private Node arrangeJarDescriptors(TargetArchiveAwareAsset asset) {
+        if (JAR_META_INF_DESCRIPTORS.contains(asset.getName())) {
+            return new NodeImpl(ArchivePaths.create(META_INF, asset.getName()), asset);
+        }
+        return null;
+    }
+
+    private static final Collection<String> EAR_META_INF_DESCRIPTORS =
+            Arrays.asList(
+                "application.xml",
+                "MANIFEST.MF");
+
+    private Node arrangeEarDescriptors(TargetArchiveAwareAsset asset) {
+        if (EAR_META_INF_DESCRIPTORS.contains(asset.getName())) {
+            return new NodeImpl(ArchivePaths.create(META_INF, asset.getName()), asset);
+        }
+        return null;
+    }
+
+}

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
@@ -48,6 +48,7 @@ import org.jboss.shrinkwrap.api.asset.ClassAsset;
 import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
 import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.asset.NamedAsset;
+import org.jboss.shrinkwrap.api.asset.TargetArchiveAwareAsset;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
@@ -350,6 +351,22 @@ public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase
         this.getArchive().add(asset, name);
         return covarientReturn();
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.jboss.shrinkwrap.api.Archive#add(org.jboss.shrinkwrap.api.asset.TargetArchiveAwareAsset)
+     */
+    @Override
+    public T add(TargetArchiveAwareAsset asset) {
+        Validate.notNull(asset, "No asset was was specified");
+
+        Node node = AssetUtil.arrangeAsset(asset, this);
+
+        add(node.getAsset(), node.getPath());
+        return covarientReturn();
+    }
+
 
     /**
      * {@inheritDoc}

--- a/impl-base/src/main/resources/META-INF/services/org.jboss.shrinkwrap.spi.TargetArchiveAwareAssetArranger
+++ b/impl-base/src/main/resources/META-INF/services/org.jboss.shrinkwrap.spi.TargetArchiveAwareAssetArranger
@@ -1,0 +1,1 @@
+org.jboss.shrinkwrap.impl.base.asset.DefaultAssetArranger

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/DynamicContainerTestBase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/DynamicContainerTestBase.java
@@ -47,6 +47,7 @@ import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.asset.DescriptiveAsset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
@@ -1996,6 +1997,26 @@ public abstract class DynamicContainerTestBase<T extends Archive<T>> extends Arc
         archive.delete(ArchivePaths.create(archivePath));
         Assert.assertFalse(archive.contains(ArchivePaths.create(archivePath)));
         Assert.assertFalse(archive.contains(ArchivePaths.create(file)));
+    }
+
+    @Test
+    @ArchiveType(JavaArchive.class)
+    public void shouldAddBeansXmlToMetaInf() throws Exception {
+        getArchive().add(new DescriptiveAsset("beans.xml"));
+
+        ArchivePath testPath = new BasicPath(getManifestPath(), "beans.xml");
+        Assert.assertTrue("Archive should contain " + testPath, getArchive().contains(testPath));
+        Assert.assertEquals(-1, getArchive().get(testPath).getAsset().openStream().read());
+    }
+
+    @Test
+    @ArchiveType(JavaArchive.class)
+    public void shouldAddFacesConfigToMetaInf() throws Exception {
+        getArchive().add(new DescriptiveAsset("faces-config.xml"));
+
+        ArchivePath testPath = new BasicPath(getManifestPath(), "faces-config.xml");
+        Assert.assertTrue("Archive should contain " + testPath, getArchive().contains(testPath));
+        Assert.assertEquals(-1, getArchive().get(testPath).getAsset().openStream().read());
     }
 
     private void assertNotContainsClass(ArchivePath notExpectedPath) {

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/DynamicEnterpriseContainerTestBase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/DynamicEnterpriseContainerTestBase.java
@@ -21,6 +21,7 @@ import junit.framework.Assert;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.asset.DescriptiveAsset;
 import org.jboss.shrinkwrap.api.container.EnterpriseContainer;
 import org.jboss.shrinkwrap.impl.base.asset.AssetUtil;
 import org.jboss.shrinkwrap.impl.base.path.BasicPath;
@@ -375,5 +376,15 @@ public abstract class DynamicEnterpriseContainerTestBase<T extends Archive<T>> e
         ArchivePath expectedPath2 = new BasicPath(getModulePath(), archive2.getName());
         Assert.assertTrue("Archive should contain " + expectedPath1, getArchive().contains(expectedPath1));
         Assert.assertTrue("Archive should contain " + expectedPath2, getArchive().contains(expectedPath2));
+    }
+
+    @Test
+    @ArchiveType(EnterpriseContainer.class)
+    public void testAddApplicationXmlDescriptiveAsset() throws Exception {
+        getArchive().add(new DescriptiveAsset("application.xml"));
+
+        ArchivePath testPath = new BasicPath(getManifestPath(), "application.xml");
+        Assert.assertTrue("Archive should contain " + testPath, getArchive().contains(testPath));
+        Assert.assertEquals(-1, getArchive().get(testPath).getAsset().openStream().read());
     }
 }

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/DynamicResourceAdapterContainerTestBase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/DynamicResourceAdapterContainerTestBase.java
@@ -4,6 +4,7 @@ import junit.framework.Assert;
 
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.asset.DescriptiveAsset;
 import org.jboss.shrinkwrap.api.container.ResourceAdapterContainer;
 import org.jboss.shrinkwrap.impl.base.asset.AssetUtil;
 import org.jboss.shrinkwrap.impl.base.path.BasicPath;
@@ -59,4 +60,15 @@ public abstract class DynamicResourceAdapterContainerTestBase<T extends Archive<
         ArchivePath testPath = new BasicPath(getResourceAdapterPath(), "ra.xml");
         Assert.assertTrue("Archive should contain " + testPath, getArchive().contains(testPath));
     }
+
+    @Test
+    @ArchiveType(ResourceAdapterContainer.class)
+    public void testAddBeansXmlDescriptiveAsset() throws Exception {
+        getArchive().add(new DescriptiveAsset("beans.xml"));
+
+        ArchivePath testPath = new BasicPath(getResourceAdapterPath(), "beans.xml");
+        Assert.assertTrue("Archive should contain " + testPath, getArchive().contains(testPath));
+        Assert.assertEquals(-1, getArchive().get(testPath).getAsset().openStream().read());
+    }
+
 }

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/DynamicWebContainerTestBase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/DynamicWebContainerTestBase.java
@@ -22,6 +22,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.DescriptiveAsset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.container.ManifestContainer;
 import org.jboss.shrinkwrap.api.container.ServiceProviderContainer;
@@ -409,6 +410,25 @@ public abstract class DynamicWebContainerTestBase<T extends Archive<T>> extends 
         Assert.assertTrue("Archive should contain " + testPath, getArchive().contains(testPath));
     }
 
+    @Test
+    @ArchiveType(WebContainer.class)
+    public void testAddBeansXmlDescriptiveAsset() throws Exception {
+        getArchive().add(new DescriptiveAsset("beans.xml"));
+
+        ArchivePath testPath = new BasicPath(getWebInfPath(), "beans.xml");
+        Assert.assertTrue("Archive should contain " + testPath, getArchive().contains(testPath));
+        Assert.assertEquals(-1, getArchive().get(testPath).getAsset().openStream().read());
+    }
+
+    @Test
+    @ArchiveType(WebContainer.class)
+    public void testAddFacesConfigDescriptiveAsset() throws Exception {
+        getArchive().add(new DescriptiveAsset("faces-config.xml"));
+
+        ArchivePath testPath = new BasicPath(getWebInfPath(), "faces-config.xml");
+        Assert.assertTrue("Archive should contain " + testPath, getArchive().contains(testPath));
+    }
+    
     /**
      * SHRINKWRAP-476
      */

--- a/spi/src/main/java/org/jboss/shrinkwrap/spi/TargetArchiveAwareAssetArranger.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/spi/TargetArchiveAwareAssetArranger.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.shrinkwrap.spi;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.TargetArchiveAwareAsset;
+/**
+ * Implementations "know" where TargetArchiveAwareAssets are located in the archive.
+ * For example the default implementation knows that a beans.xml is located at WEB-INF
+ * in a war file and at META-INF in other jar files.
+ *
+ * @author <a href="mailto:robert.panzer@me.com">Robert Panzer</a>
+ */
+public interface TargetArchiveAwareAssetArranger {
+
+    /**
+     * Creates a node with the correct path for the specified asset and archive.
+     * E.g. for an asset with name beans.xml and an archive with a name ending
+     * on .war it should return a {@link Node} with path WEB-INF/beans.xml and
+     * the given asset as the nodes asset.
+     * @param asset
+     * @param archive
+     * @return The {@link Node} having the archive path and asset to be added to
+     * the archive.
+     */
+    Node arrange(TargetArchiveAwareAsset asset, Archive<?> archive);
+
+}


### PR DESCRIPTION
...efault Java EE descriptors
This new PR goes back to discussions with @aslakknutsen on PR #85

Instead of having methods like WebArchive.setBeansXml() as in the original PR this one proposes an API like

`ShrinkWrap.create(WebArchive.class).add(new DescriptiveAsset("beans.xml"))`

to get a beans.xml sorted into the correct location. ShrinkWrap Descriptors could be put on top of that to also get descriptors sorted automatically at the correct location.

The current implementation knows some standard descriptor names. IMO that should probably expanded to also sort `jboss-ejb3.xml`, `jboss-web.xml`, `ibm-ejb-jar-bnd.xm[il]` etc.

Maybe I am too intrusive with this but I wanted at least to implement this thing as there was a lengthy constructive discussion around the original PR. 
But maybe there is not really a need for a functionality like this, as developers should know where descriptors have to be placed, at latest when they are packaging their productive archives. (Personally I am only using CDI in tests, currently not possible in the productive software due to problems with AS7)
