### PR TITLE
SHRINKWRAP-490 Add exportExplodedInto API to ExplodedExporter

### DIFF
--- a/api/src/main/java/org/jboss/shrinkwrap/api/exporter/ExplodedExporter.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/exporter/ExplodedExporter.java
@@ -36,7 +36,6 @@ public interface ExplodedExporter extends Assignable {
     /**
      * Exports provided archive as an exploded directory structure.
      *
-     * @param archive
      * @param parentDirectory
      *            Must be a folder
      * @return File for exploded archive contents
@@ -50,7 +49,6 @@ public interface ExplodedExporter extends Assignable {
     /**
      * Exports provided archive as an exploded directory structure.
      *
-     * @param archive
      * @param parentDirectory
      *            Must be a folder
      * @param directoryName
@@ -62,4 +60,18 @@ public interface ExplodedExporter extends Assignable {
      *             if the export process fails
      */
     File exportExploded(File parentDirectory, String directoryName);
+
+    /**
+     * Exports provided archive as an exploded directory structure
+     * into the given directory.
+     *
+     * @param directory
+     *            Must be a folder
+     * @return File for exploded archive contents
+     * @throws IllegalArgumentException
+     *             if the archive or parent directory not valid
+     * @throws ArchiveExportException
+     *             if the export process fails
+     */
+    File exportExplodedInto(File directory);
 }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/ExplodedExporterDelegate.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/ExplodedExporterDelegate.java
@@ -66,9 +66,11 @@ public class ExplodedExporterDelegate extends AbstractExporterDelegate<File> {
     /**
      * Creates a new exploded exporter delegate for the provided {@link Archive}
      */
-    public ExplodedExporterDelegate(Archive<?> archive, File baseDirectory, String directoryName) {
+    public ExplodedExporterDelegate(Archive<?> archive, File outputDirectory) {
         super(archive);
-        this.outputDirectory = initializeOutputDirectory(baseDirectory, directoryName);
+        this.outputDirectory = outputDirectory;
+
+        validateOutputDirectory(outputDirectory);
     }
 
     // -------------------------------------------------------------------------------------||
@@ -173,9 +175,8 @@ public class ExplodedExporterDelegate extends AbstractExporterDelegate<File> {
      * @param directoryName
      * @return
      */
-    private File initializeOutputDirectory(File baseDirectory, String directoryName) {
+    private File validateOutputDirectory(File outputDirectory) {
         // Create output directory
-        final File outputDirectory = new File(baseDirectory, directoryName);
         if (!outputDirectory.mkdir() && !outputDirectory.exists()) {
             throw new ArchiveExportException("Unable to create archive output directory - " + outputDirectory);
         }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/ExplodedExporterImpl.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/exporter/ExplodedExporterImpl.java
@@ -87,9 +87,20 @@ public class ExplodedExporterImpl extends AssignableBase<Archive<?>> implements 
             throw new IllegalArgumentException("Provided parent directory is not a valid directory");
         }
 
+        return export(archive, new File(baseDirectory, directoryName));
+    }
+
+    @Override
+    public File exportExplodedInto(File directory) {
+        final Archive<?> archive = this.getArchive();
+        Validate.notNull(archive, "No archive provided");
+
+        return export(archive, directory);
+    }
+
+    private File export(final Archive<?> archive, File outputDirectory) {
         // Get the export delegate
-        final ExplodedExporterDelegate exporterDelegate = new ExplodedExporterDelegate(archive, baseDirectory,
-            directoryName);
+        final ExplodedExporterDelegate exporterDelegate = new ExplodedExporterDelegate(archive, outputDirectory);
 
         // Run the export and get the result
         final File explodedDirectory = exporterDelegate.export();
@@ -100,5 +111,4 @@ public class ExplodedExporterImpl extends AssignableBase<Archive<?>> implements 
         // Return the exploded dir
         return explodedDirectory;
     }
-
 }

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/exporter/ExplodedExporterTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/exporter/ExplodedExporterTestCase.java
@@ -190,6 +190,30 @@ public class ExplodedExporterTestCase extends ExportTestBase {
         assertAssetInExploded(explodedDirectory, new BasicPath(nestedArchivePathTwo, PATH_TWO), ASSET_TWO);
     }
 
+    @Test
+    public void testExportExplodedIntoDirectory() throws Exception {
+        log.info("testExportExplodedIntoDirectory");
+
+        // Get a temp directory
+        File tempDirectory = createTempDirectory("testExportExploded");
+
+        // Get an archive instance
+        Archive<?> archive = createArchiveWithAssets();
+
+        // Export as Exploded directory
+        File explodedDirectory = archive.as(ExplodedExporter.class).exportExplodedInto(tempDirectory);
+
+        // Validate the exploded directory was created
+        Assert.assertNotNull(explodedDirectory);
+
+        // Validate the exploded directory was created in same directory
+        Assert.assertEquals(tempDirectory, explodedDirectory);
+
+        // Validate entries were written out
+        assertAssetInExploded(explodedDirectory, PATH_ONE, ASSET_ONE);
+        assertAssetInExploded(explodedDirectory, PATH_TWO, ASSET_TWO);
+    }
+
     /**
      * Ensure an baseDirectory is required to export.
      *


### PR DESCRIPTION
Allow to export exploded directly to a target directory without
creating a child root folder.