### PR TITLE
Add support to be able to filter import/export to/from Archive

### DIFF
--- a/api/src/main/java/org/jboss/shrinkwrap/api/Archive.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/Archive.java
@@ -385,6 +385,17 @@ public interface Archive<T extends Archive<T>> extends Assignable {
     Map<ArchivePath, Node> getContent(Filter<ArchivePath> filter);
 
     /**
+     * Obtains all assets matching given filter in this archive as a new Archive.<br/>
+     * <br/>
+     * This is an alias for shallowCopy(Filter).
+     *
+     * @see org.jboss.shrinkwrap.api.Archive#shallowCopy(Filter)
+     * @param filter
+     * @return
+     */
+    T filter(Filter<ArchivePath> filter);
+
+    /**
      * Add an archive under a specific context and maintain the archive name as context path.
      *
      * @param path
@@ -580,4 +591,12 @@ public interface Archive<T extends Archive<T>> extends Assignable {
      */
     Archive<T> shallowCopy();
 
+    /**
+     * Creates a shallow copy of this {@link Archive} based on given filter.Assets from this archive are made available
+     * under the same paths. However, removing old assets or adding new assets on this archive affects does not affect
+     * the new archive.
+     *
+     * @return a new archive with a copy of the pointers to the assets
+     */
+    Archive<T> shallowCopy(Filter<ArchivePath> filter);
 }

--- a/api/src/main/java/org/jboss/shrinkwrap/api/importer/StreamImporter.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/api/importer/StreamImporter.java
@@ -23,7 +23,9 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipInputStream;
 
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.Assignable;
+import org.jboss.shrinkwrap.api.Filter;
 
 /**
  * Generic importer capable of representing an {@link Assignable} as an entity capable of reading from an
@@ -52,15 +54,46 @@ public interface StreamImporter<I extends StreamImporter<I>> extends Assignable 
     I importFrom(InputStream stream) throws ArchiveImportException;
 
     /**
+     * Imports provided stream as a {@link Archive}. It remains the responsibility of the caller to close the stream.
+     *
+     * @param stream
+     *            the stream to import; should be a raw type, not wrapped in any implementation-specific encoding (ie.
+     *            {@link FileInputStream} is appropriate, but {@link ZipInputStream} or {@link GZIPInputStream} is not).
+     * @param filter
+     *            Filter to match result
+     * @return Archive of the imported stream
+     * @throws ArchiveImportException
+     *             If an error occurred during the import process
+     * @throws IllegalArgumentException
+     *             If no stream is specified
+     */
+    I importFrom(InputStream stream, Filter<ArchivePath> filter) throws ArchiveImportException;
+
+    /**
      * Imports provided File as a {@link Archive}.
      *
      * @param file
      *            the file to import
-     * @return Archive of the imported Zip
+     * @return Archive of the imported file
      * @throws ArchiveImportException
      *             If an error occurred during the import process
      * @throws IllegalArgumentException
      *             If no file is specified or if the file is a directory
      */
     I importFrom(File file) throws ArchiveImportException;
+
+    /**
+     * Imports provided File as a {@link Archive}.
+     *
+     * @param file
+     *            the file to import
+     * @param filter
+     *            Filter to match result
+     * @return Archive of the imported file
+     * @throws ArchiveImportException
+     *             If an error occurred during the import process
+     * @throws IllegalArgumentException
+     *             If no file is specified or if the file is a directory
+     */
+    I importFrom(File file, Filter<ArchivePath> filter) throws ArchiveImportException;
 }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/ArchiveBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/ArchiveBase.java
@@ -345,6 +345,16 @@ public abstract class ArchiveBase<T extends Archive<T>> implements Archive<T>, C
     /**
      * {@inheritDoc}
      *
+     * @see org.jboss.shrinkwrap.api.Archive#filter(Filter)
+     */
+    @Override
+    public T filter(Filter<ArchivePath> filter) {
+        return this.shallowCopy(filter).as(getActualClass());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.jboss.shrinkwrap.api.Archive#add(org.jboss.shrinkwrap.api.Archive, org.jboss.shrinkwrap.api.ArchivePath,
      *      java.lang.Class)
      */
@@ -524,6 +534,17 @@ public abstract class ArchiveBase<T extends Archive<T>> implements Archive<T>, C
      */
     @Override
     public final Archive<T> shallowCopy() {
+        return this.shallowCopy(Filters.includeAll());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.jboss.shrinkwrap.api.Archive#shallowCopy(Filter)
+     */
+    @Override
+    public final Archive<T> shallowCopy(Filter<ArchivePath> filter) {
+        Validate.notNull(filter, "Filter must be specified");
         // Use existing configuration
         final Configuration configuration = this.getConfiguration();
 
@@ -557,6 +578,9 @@ public abstract class ArchiveBase<T extends Archive<T>> implements Archive<T>, C
         for (final ArchivePath path : from.getContent().keySet()) {
             Asset asset = from.get(path).getAsset();
             if (asset != null) {
+                if(!filter.include(path)) {
+                    continue;
+                }
                 to.add(asset, path);
             }
         }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
@@ -482,6 +482,15 @@ public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase
     /**
      * {@inheritDoc}
      *
+     * @see org.jboss.shrinkwrap.api.Archive#filter(Filter)
+     */
+    @Override
+    public T filter(Filter<ArchivePath> filter) {
+        return this.shallowCopy(filter).as(getActualClass());
+    }
+    /**
+     * {@inheritDoc}
+     *
      * @see org.jboss.shrinkwrap.api.Archive#getContent()
      */
     @Override
@@ -526,6 +535,18 @@ public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase
      */
     @Override
     public Archive<T> shallowCopy() {
+        return this.shallowCopy(Filters.includeAll());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.jboss.shrinkwrap.api.Archive#shallowCopy(Filter)
+     */
+    @Override
+    public Archive<T> shallowCopy(Filter<ArchivePath> filter) {
+        Validate.notNull(filter, "Filter must be specified");
+
         // Get the actual class type and make a shallow copy of the the underlying archive,
         // using the same underlying configuration
         final Class<T> actualClass = this.getActualClass();
@@ -538,6 +559,9 @@ public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase
         for (final ArchivePath path : contents.keySet()) {
             Asset asset = contents.get(path).getAsset();
             if (asset != null) {
+                if(!filter.include(path)) {
+                    continue;
+                }
                 newArchive.add(asset, path);
             }
         }

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/importer/ZipImporterImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/importer/ZipImporterImplTestCase.java
@@ -16,20 +16,6 @@
  */
 package org.jboss.shrinkwrap.impl.base.importer;
 
-import org.jboss.shrinkwrap.api.ArchiveFormat;
-import org.jboss.shrinkwrap.api.ArchivePaths;
-import org.jboss.shrinkwrap.api.GenericArchive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.exporter.StreamExporter;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
-import org.jboss.shrinkwrap.api.importer.ArchiveImportException;
-import org.jboss.shrinkwrap.api.importer.ZipImporter;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,6 +23,17 @@ import java.util.Enumeration;
 import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
+import org.jboss.shrinkwrap.api.ArchiveFormat;
+import org.jboss.shrinkwrap.api.GenericArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.StreamExporter;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.importer.ArchiveImportException;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * TestCase to verify the ZipImporter functionality.

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/ArchiveTestBase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/ArchiveTestBase.java
@@ -24,9 +24,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
-
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchiveFormat;
 import org.jboss.shrinkwrap.api.ArchivePath;
@@ -45,6 +42,7 @@ import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.asset.NamedAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.impl.base.TestIOUtil;
 import org.jboss.shrinkwrap.impl.base.Validate;
@@ -54,7 +52,9 @@ import org.jboss.shrinkwrap.impl.base.test.handler.ReplaceAssetHandler;
 import org.jboss.shrinkwrap.impl.base.test.handler.SimpleHandler;
 import org.jboss.shrinkwrap.spi.ArchiveFormatAssociable;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
+
 
 /**
  * ArchiveTestBase
@@ -365,9 +365,9 @@ public abstract class ArchiveTestBase<T extends Archive<T>> {
 
         // Test
         final String message = "Should be able to add directory: ";
-        TestCase.assertTrue(message + path1, archive.contains(path1));
-        TestCase.assertTrue(message + path2, archive.contains(path2));
-        TestCase.assertTrue(message + path3, archive.contains(path3));
+        Assert.assertTrue(message + path1, archive.contains(path1));
+        Assert.assertTrue(message + path2, archive.contains(path2));
+        Assert.assertTrue(message + path3, archive.contains(path3));
     }
 
     @Test
@@ -778,6 +778,19 @@ public abstract class ArchiveTestBase<T extends Archive<T>> {
             jar.get("test/classloader/DummyClass$DummyInnerClass.class"));
         Assert.assertNotNull("Should contain a new asset", ((ArchiveAsset) archive.get(resourcePath).getAsset())
             .getArchive().get("test.txt"));
+    }
+
+    @Test
+    public void testFilter() throws Exception {
+
+        String resourcePath = "/test/cl-test.jar";
+        GenericArchive archive = ShrinkWrap.create(ZipImporter.class).importFrom(
+            TestIOUtil.createFileFromResourceName("cl-test.jar")).as(GenericArchive.class);
+
+        GenericArchive filtered = archive.filter(Filters.include(".*MANIFEST\\.MF"));
+        // Check that only META-INF/MANIFEST.MF exist in Archive
+        Assert.assertEquals(2, filtered.getContent().size());
+        Assert.assertTrue(filtered.contains(ArchivePaths.create("META-INF/MANIFEST.MF")));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
```java
ShrinkWrap.create(ZipImporter.class).importFrom(File, Filters.incldue("X"))
```

```java
archive.filter(Filters.incldue("X")).as(ZipExporter.class).exportTo(File)
```
