### PR TITLE
Fixes SHRINKWRAP-480: Preserve order of entries in archives.

### DIFF
--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/MemoryMapArchiveBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/MemoryMapArchiveBase.java
@@ -18,15 +18,13 @@ package org.jboss.shrinkwrap.impl.base;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchiveEvent;
@@ -63,12 +61,12 @@ public abstract class MemoryMapArchiveBase<T extends Archive<T>> extends Archive
     /**
      * Storage for the {@link Node}s.
      */
-    private final ConcurrentMap<ArchivePath, NodeImpl> content = new ConcurrentHashMap<ArchivePath, NodeImpl>();
+    private final Map<ArchivePath, NodeImpl> content = Collections.synchronizedMap(new LinkedHashMap<ArchivePath, NodeImpl>());
 
     /**
      * Storage for the {@link ArchiveAsset}s. Used to help get access to nested archive content.
      */
-    private final ConcurrentMap<ArchivePath, ArchiveAsset> nestedArchives = new ConcurrentHashMap<ArchivePath, ArchiveAsset>();
+    private final Map<ArchivePath, ArchiveAsset> nestedArchives = Collections.synchronizedMap(new LinkedHashMap<ArchivePath, ArchiveAsset>());
 
     private final List<ArchiveEventHandler> handlers = new ArrayList<ArchiveEventHandler>();
 
@@ -358,7 +356,7 @@ public abstract class MemoryMapArchiveBase<T extends Archive<T>> extends Archive
      */
     @Override
     public Map<ArchivePath, Node> getContent() {
-        Map<ArchivePath, Node> ret = new HashMap<ArchivePath, Node>();
+        Map<ArchivePath, Node> ret = new LinkedHashMap<ArchivePath, Node>();
         for (Map.Entry<ArchivePath, NodeImpl> item : content.entrySet()) {
             if (!item.getKey().equals(new BasicPath("/"))) {
                 ret.put(item.getKey(), item.getValue());
@@ -377,7 +375,7 @@ public abstract class MemoryMapArchiveBase<T extends Archive<T>> extends Archive
     public Map<ArchivePath, Node> getContent(Filter<ArchivePath> filter) {
         Validate.notNull(filter, "Filter must be specified");
 
-        Map<ArchivePath, Node> filteredContent = new HashMap<ArchivePath, Node>();
+        Map<ArchivePath, Node> filteredContent = new LinkedHashMap<ArchivePath, Node>();
         for (Map.Entry<ArchivePath, NodeImpl> contentEntry : content.entrySet()) {
             if (filter.include(contentEntry.getKey())) {
                 if (!contentEntry.getKey().equals(new BasicPath("/"))) {

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/NodeImpl.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/NodeImpl.java
@@ -17,7 +17,7 @@
 package org.jboss.shrinkwrap.impl.base;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.Archive;
@@ -49,7 +49,7 @@ public class NodeImpl implements Node {
     /**
      * The children nodes.
      */
-    private Set<Node> children = Collections.synchronizedSet(new HashSet<Node>());
+    private Set<Node> children = Collections.synchronizedSet(new LinkedHashSet<Node>());
 
     // -------------------------------------------------------------------------------------||
     // Constructor ------------------------------------------------------------------------||

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/PreserveOrderOfEntriesTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/PreserveOrderOfEntriesTestCase.java
@@ -1,0 +1,88 @@
+package org.jboss.shrinkwrap.impl.base;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.logging.Logger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.Assert.*;
+
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Ensures that entries added to the archives preserve the order they are
+ * added in.
+ *
+ * SHRINKWRAP-480
+ *
+ * @author <a href="mailto:hiram@hiramchirino.com">Hiram Chirino</a>
+ * @version $Revision: $
+ */
+public class PreserveOrderOfEntriesTestCase {
+
+    // -------------------------------------------------------------------------------------||
+    // Tests ------------------------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    @Test
+    public void canPreserveOrder() throws Exception {
+        File target = new File("target");
+        target.mkdirs();
+        File testJar = new File(target, "test.jar");
+        testJar.delete();
+
+        ArrayList<String> expectedOrder = new ArrayList<String>();
+        ArrayList<String> actualOrder = new ArrayList<String>();
+
+        assertFalse(testJar.exists());
+
+        // Create an archive with resources
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, testJar.getName());
+        Random random = new Random(0);
+        for (int i = 0; i < 1000; i++) {
+            String name = "f" + Long.toHexString(random.nextLong());
+            expectedOrder.add(name);
+            archive.addAsResource(new StringAsset("content"), name);
+        }
+        archive.as(ZipExporter.class).exportTo(testJar, true);
+
+        assertTrue(testJar.exists());
+
+
+        ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(testJar));
+        ZipEntry nextEntry = zipInputStream.getNextEntry();
+        while( nextEntry!=null ) {
+            actualOrder.add(nextEntry.getName());
+            nextEntry = zipInputStream.getNextEntry();
+        }
+
+        assertEquals(expectedOrder, actualOrder);
+        testJar.delete();
+    }
+
+
+}

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/PreserveOrderOfEntriesTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/PreserveOrderOfEntriesTestCase.java
@@ -10,11 +10,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.Random;
-import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /*
  * JBoss, Home of Professional Open Source
@@ -55,15 +56,17 @@ public class PreserveOrderOfEntriesTestCase {
         File testJar = new File(target, "test.jar");
         testJar.delete();
 
+        if( testJar.exists() ) {
+            throw new Exception("Test setup failed");
+        }
+
         ArrayList<String> expectedOrder = new ArrayList<String>();
         ArrayList<String> actualOrder = new ArrayList<String>();
-
-        assertFalse(testJar.exists());
 
         // Create an archive with resources
         JavaArchive archive = ShrinkWrap.create(JavaArchive.class, testJar.getName());
         Random random = new Random(0);
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 5; i++) {
             String name = "f" + Long.toHexString(random.nextLong());
             expectedOrder.add(name);
             archive.addAsResource(new StringAsset("content"), name);


### PR DESCRIPTION
In some cases like felix OSGi bundles you have to make sure that the manifest file is the first entry in the jar.  So we might as well preserve the order of entries.

Fixes https://issues.jboss.org/browse/SHRINKWRAP-480