### PR TITLE
SHRINKWRAP-505 - Allow addPackage() to be smarter about .war files

### DIFF
--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
@@ -17,6 +17,7 @@
 package org.jboss.shrinkwrap.impl.base.container;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
@@ -1505,12 +1506,12 @@ public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase
 
         final URLPackageScanner.Callback callback = new URLPackageScanner.Callback() {
             @Override
-            public void classFound(String className) {
+            public void classFound(String className, Asset asset) {
                 ArchivePath classNamePath = AssetUtil.getFullPathForClassResource(className);
                 if (!filter.include(classNamePath)) {
                     return;
                 }
-                Asset asset = new ClassLoaderAsset(classNamePath.get().substring(1), classLoader);
+                //Asset asset = new ClassLoaderAsset(classNamePath.get().substring(1), classLoader);
                 ArchivePath location = new BasicPath(getClassesPath(), classNamePath);
                 add(asset, location);
             }
@@ -1689,7 +1690,7 @@ public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase
 
         final URLPackageScanner.Callback callback = new URLPackageScanner.Callback() {
             @Override
-            public void classFound(String className) {
+            public void classFound(String className, Asset asset) {
                 ArchivePath classNamePath = AssetUtil.getFullPathForClassResource(className);
 
                 if (!filter.include(classNamePath)) {

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/URLPackageScannerTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/URLPackageScannerTestCase.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.shrinkwrap.impl.base;
 
+import java.io.IOException;
+
+import org.jboss.shrinkwrap.api.asset.Asset;
 import org.junit.Test;
 
 /**
@@ -32,7 +35,7 @@ public class URLPackageScannerTestCase {
         URLPackageScanner.newInstance(true, URLPackageScannerTestCase.class.getClassLoader(),
             new URLPackageScanner.Callback() {
                 @Override
-                public void classFound(String className) {
+                public void classFound(String className, Asset asset) {
                 }
             }, null);
     }

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/AddPackageFromWarTest.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/spec/AddPackageFromWarTest.java
@@ -1,0 +1,102 @@
+package org.jboss.shrinkwrap.impl.base.spec;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import junit.framework.Assert;
+import org.jboss.shrinkwrap.api.ConfigurationBuilder;
+import org.jboss.shrinkwrap.api.Domain;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.base.spec.donotchange.DummyClassA;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Bob McWhirter
+ */
+public class AddPackageFromWarTest {
+
+    private Domain domain;
+
+    private Path temp;
+
+    @Before
+    public void setUp() throws IOException {
+
+        ConfigurationBuilder builder = new ConfigurationBuilder();
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "my.war");
+        war.addClass(DummyClassA.class);
+
+        this.temp = Files.createTempFile("test", ".war");
+        war.as(ZipExporter.class).exportTo(temp.toFile(), true);
+        URL warUrl = temp.toUri().toURL();
+
+        List<ClassLoader> classLoaders = new ArrayList<ClassLoader>();
+
+        URLClassLoader warCl = new URLClassLoader(new URL[]{warUrl}, null);
+        classLoaders.add(warCl);
+
+        ClassLoader shrinkwrapCl = new FilteringClassLoader(this.getClass().getClassLoader());
+        classLoaders.add(shrinkwrapCl);
+
+        builder.classLoaders(classLoaders);
+
+        // Create a domain that includes the `donotchange` classes within a .war
+        // and the rest, excluding `donotchange` from the regular app classloader.
+        this.domain = ShrinkWrap.createDomain(builder.build());
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        Files.delete( this.temp );
+    }
+
+    @Test
+    public void testAddPackage() {
+        // This archive's classloaders should be the app classloader (without `donotchange`)
+        // and an .war-based classloader including the `donotchange` within WEB-INF/classes/...
+
+        JavaArchive jar = this.domain.getArchiveFactory().create(JavaArchive.class);
+        jar.addPackage("org.jboss.shrinkwrap.impl.base.spec.donotchange" );
+        Assert.assertNotNull( jar.get( "/" + DummyClassA.class.getName().replace( '.', '/' ) + ".class" ) );
+    }
+
+    /** Classloader to ensure the donotchange bits are not loaded through
+     * the app-classloader, while still enabling the default ShrinkWrap
+     * bits to be found through the junit test.
+     */
+    private static class FilteringClassLoader extends ClassLoader {
+
+        public FilteringClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (name.contains("donotchange")) {
+                return null;
+            }
+            return super.loadClass(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (name.contains("donotchange")) {
+                return Collections.emptyEnumeration();
+            }
+            return super.getResources(name);
+        }
+
+    }
+}


### PR DESCRIPTION
This commit brings about the smartness required for URLPackageScanner
to understand that a URL that represents a .war has its classes
relocated under WEB-INF/lib instead of from the root of the archive.

Part of the change is pre-constructing the Asset passed to the
scanner's Callback, taking into account the location of the underlying
asset, separate from it's actual related class name.