### PR TITLE
#124 Repair moving of archive nodes with multiple children

### DIFF
--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/ArchiveBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/ArchiveBase.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -646,8 +647,10 @@ public abstract class ArchiveBase<T extends Archive<T>> implements Archive<T>, C
         }
 
         // move children
-        final Set<Node> nodeToMoveChildren = nodeToMove.getChildren();
-        for (final Node child : nodeToMoveChildren) {
+
+        // can't remove from collection inside of the iteration
+        final Set<Node> nodeToMoveChildrenCopy = new HashSet<Node>(nodeToMove.getChildren());
+        for (final Node child : nodeToMoveChildrenCopy) {
             final String childName = child.getPath().get().replaceFirst(child.getPath().getParent().get(), "");
             final ArchivePath childTargetPath = ArchivePaths.create(target, childName);
             move(child.getPath(), childTargetPath);

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/ArchiveTestBase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/test/ArchiveTestBase.java
@@ -1409,18 +1409,23 @@ public abstract class ArchiveTestBase<T extends Archive<T>> {
         final String childDirPath = sourcePath + "/" + childDirName;
         final String childDirTargetPath = targetPath + "/" + childDirName;
 
-        final String childFileName = "file1";
-        final String childFilePath = childDirPath + "/" + childFileName;
-        final String childFileTargetPath = childDirTargetPath + "/" + childFileName;
+        final String childFileName1 = "file1";
+        final String childFilePath1 = childDirPath + "/" + childFileName1;
+        final String childFileTargetPath1 = childDirTargetPath + "/" + childFileName1;
+        final String childFileName2 = "file2";
+        final String childFilePath2 = childDirPath + "/" + childFileName2;
+        final String childFileTargetPath2 = childDirTargetPath + "/" + childFileName2;
 
         archive.addAsDirectory(sourcePath);
-        archive.addAsDirectory(childDirName);
-        archive.add(EmptyAsset.INSTANCE, childFilePath);
+        archive.addAsDirectory(childDirPath);
+        archive.add(EmptyAsset.INSTANCE, childFilePath1);
+        archive.add(EmptyAsset.INSTANCE, childFilePath2);
         archive.move(sourcePath, targetPath);
 
         Assert.assertTrue("Directory should be at the new path", archive.get(targetPath).getAsset() == null);
         Assert.assertTrue("Child dir should be at the new path", archive.get(childDirTargetPath).getAsset() == null);
-        Assert.assertTrue("Child asset should be at the new path", archive.get(childFileTargetPath).getAsset() != null);
+        Assert.assertTrue("Child asset1 should be at the new path", archive.get(childFileTargetPath1).getAsset() != null);
+        Assert.assertTrue("Child asset2 should be at the new path", archive.get(childFileTargetPath2).getAsset() != null);
     }
 
     @Test(expected = IllegalArchivePathException.class)


### PR DESCRIPTION
This patch can be merged to branch **1.2.x** and **master** and repair moving nods with multiple children.