### PR TITLE
Fix adjustedPath on Windows

### DIFF
--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java
@@ -813,6 +813,7 @@ public abstract class ContainerBase<T extends Archive<T>> extends AssignableBase
         if(indexOfExclamationPoint!=-1){
             adjustedPath = path.substring(indexOfExclamationPoint + 2, path.length());
         }
+        adjustedPath = adjustedPath.replace(File.separator, "/");
 
         for (final ClassLoader classLoader : classLoaders) {
             final InputStream in = classLoader.getResourceAsStream(adjustedPath);


### PR DESCRIPTION
Commit 4293b548379d1ebe3728d6b20d10d8e5cd97c51f removes the code that replaces the File.seperator with a forward slash.
This replacement is necessary on Windows, so this removal makes that resources from a JAR can no longer be found while trying to add them to the archive.

Example: See https://github.com/arquillian/arquillian-core/blob/master/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_3/ProtocolDeploymentAppender.java#L41. The resource "org/jboss/arquillian/protocol/servlet/v_3/web-fragment.xml" is added, which leads to this method https://github.com/shrinkwrap/shrinkwrap/blob/main/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/container/ContainerBase.java#L805. On Windows, `adjustedPath` = org\jboss\arquillian\protocol\servlet\v_3\web-fragment.xml and the resource cannot be found, which leads to the IllegalArgumentException thrown on L824. Replacing `adjustedPath` with org/jboss/arquillian/protocol/servlet/v_3/web-fragment.xml solves this problem.