### PR TITLE
Optimize ZipImporter to buffer streams to disk to prevent OOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "myFilteredArchive.ja
     .filter(Filters.exclude(".*\\.log"));  // Exclude all .log files
 ```
 
+### Configuration
+
+When importing large ZIP archives from streams, ShrinkWrap buffers the content to a temporary file to avoid `OutOfMemoryError`. The threshold defaults to 100 MB and can be adjusted via `-Dshrinkwrap.zipImporter.diskBufferThresholdMb=<value>`.
+
 ### Contributing
 
 If you have suggestions for improvements or would like to contribute to ShrinkWrap, please visit our [issue tracker](https://github.com/shrinkwrap/shrinkwrap/issues) for the SHRINKWRAP project.

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/importer/zip/ZipImporterImpl.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/impl/base/importer/zip/ZipImporterImpl.java
@@ -18,6 +18,7 @@ package org.jboss.shrinkwrap.impl.base.importer.zip;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Enumeration;
@@ -46,6 +47,11 @@ import org.jboss.shrinkwrap.impl.base.path.BasicPath;
  * @version $Revision: $
  */
 public class ZipImporterImpl extends AssignableBase<Archive<?>> implements ZipImporter {
+
+    /**
+     * System property to override the default disk buffer threshold (in MB).
+     */
+    static final String DISK_BUFFER_THRESHOLD_PROPERTY = "shrinkwrap.zipImporter.diskBufferThresholdMb";
 
     // -------------------------------------------------------------------------------------||
     // Constructor ------------------------------------------------------------------------||
@@ -104,15 +110,41 @@ public class ZipImporterImpl extends AssignableBase<Archive<?>> implements ZipIm
         Validate.notNull(filter, "Filter must be specified");
 
         try {
-            // Wrap in ZipInputStream if we haven't been given one
-            final ZipInputStream zipStream = new ZipInputStream(stream);
+            final long diskBufferThreshold = Long.getLong(DISK_BUFFER_THRESHOLD_PROPERTY, 100L) * 1024 * 1024;
+
+            // Buffer the stream into memory, tracking total size
+            final ByteArrayOutputStream memoryBuffer = new ByteArrayOutputStream(8192);
+            final byte[] buf = new byte[4096];
+            int bytesRead;
+            long totalRead = 0;
+
+            while ((bytesRead = stream.read(buf)) != -1) {
+                memoryBuffer.write(buf, 0, bytesRead);
+                totalRead += bytesRead;
+
+                if (totalRead > diskBufferThreshold) {
+                    // Threshold exceeded, spill to disk
+                    final File tempFile = File.createTempFile("shrinkwrap-buffer", ".tmp");
+                    tempFile.deleteOnExit();
+
+                    try (FileOutputStream fileOutput = new FileOutputStream(tempFile)) {
+                        memoryBuffer.writeTo(fileOutput);
+                        IOUtil.copy(stream, fileOutput);
+                    }
+
+                    return importFrom(tempFile, filter);
+                }
+            }
+
+            // Small archive, process directly from memory using ZipInputStream
+            final ZipInputStream zipStream = new ZipInputStream(new java.io.ByteArrayInputStream(memoryBuffer.toByteArray()));
 
             ZipEntry entry;
             while ((entry = zipStream.getNextEntry()) != null) {
                 // Get the name
                 final String entryName = entry.getName();
 
-                if(!filter.include(ArchivePaths.create(entryName))) {
+                if (!filter.include(ArchivePaths.create(entryName))) {
                     zipStream.closeEntry();
                     continue;
                 }
@@ -131,10 +163,11 @@ public class ZipImporterImpl extends AssignableBase<Archive<?>> implements ZipIm
                 archive.add(new ByteArrayAsset(output.toByteArray()), entryName);
                 zipStream.closeEntry();
             }
+            return this;
+
         } catch (IOException e) {
             throw new ArchiveImportException("Could not import stream", e);
         }
-        return this;
     }
 
     /**

--- a/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/importer/ZipImporterImplTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/impl/base/importer/ZipImporterImplTestCase.java
@@ -19,18 +19,25 @@ package org.jboss.shrinkwrap.impl.base.importer;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchiveFormat;
 import org.jboss.shrinkwrap.api.GenericArchive;
+import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.exporter.StreamExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.importer.ArchiveImportException;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.impl.base.asset.ZipFileEntryAsset;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -52,28 +59,12 @@ public class ZipImporterImplTestCase extends StreamImporterImplTestBase<ZipImpor
     private static final ZipContentAssertionDelegate delegate = new ZipContentAssertionDelegate();
 
     // -------------------------------------------------------------------------------------||
-    // Tests -------------------------------------------------------------------------------||
+    // Lifecycle --------------------------------------------------------------------------||
     // -------------------------------------------------------------------------------------||
 
-    /**
-     * Ensures that an import of {@link ZipFile} results in {@link ArchiveImportException} if an unexpected error
-     * occurred.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void shouldThrowExceptionOnErrorInImportFromFile() throws Exception {
-        final ContentAssertionDelegateBase delegate = this.getDelegate();
-        assert delegate != null : "Delegate must be specified by implementations";
-        final File testFile = delegate.getExistingResource();
-
-        try (ZipFile testZip = new ZipFile(testFile) {
-            @Override
-            public Enumeration<? extends ZipEntry> entries() {
-                throw new IllegalStateException("mock exception"); }}) {
-            Assertions.assertThrows(ArchiveImportException.class,
-                    () -> ShrinkWrap.create(ZipImporter.class, "test.jar").importFrom(testZip).as(JavaArchive.class));
-        }
+    @AfterEach
+    public void clearDiskBufferThreshold() {
+        System.clearProperty("shrinkwrap.zipImporter.diskBufferThresholdMb");
     }
 
     // -------------------------------------------------------------------------------------||
@@ -138,6 +129,87 @@ public class ZipImporterImplTestCase extends StreamImporterImplTestBase<ZipImpor
     // -------------------------------------------------------------------------------------||
     // Tests -------------------------------------------------------------------------------||
     // -------------------------------------------------------------------------------------||
+
+    /**
+     * Ensures that an import of {@link ZipFile} results in {@link ArchiveImportException} if an unexpected error
+     * occurred.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void shouldThrowExceptionOnErrorInImportFromFile() throws Exception {
+        final ContentAssertionDelegateBase delegate = this.getDelegate();
+        assert delegate != null : "Delegate must be specified by implementations";
+        final File testFile = delegate.getExistingResource();
+
+        try (ZipFile testZip = new ZipFile(testFile) {
+            @Override
+            public Enumeration<? extends ZipEntry> entries() {
+                throw new IllegalStateException("mock exception"); }}) {
+            Assertions.assertThrows(ArchiveImportException.class,
+                    () -> ShrinkWrap.create(ZipImporter.class, "test.jar").importFrom(testZip).as(JavaArchive.class));
+        }
+    }
+
+    /**
+     * Ensures that importing a stream smaller than the disk buffer threshold
+     * processes the archive in memory and produces correct content.
+     */
+    @Test
+    public void shouldImportStreamInMemoryWhenBelowThreshold() throws Exception {
+        final File testFile = delegate.getExistingResource();
+
+        try (InputStream stream = Files.newInputStream(testFile.toPath())) {
+            final Archive<?> archive = ShrinkWrap.create(ZipImporter.class, "test.jar")
+                    .importFrom(stream).as(JavaArchive.class);
+
+            Assertions.assertNotNull(archive, "Should not return a null archive");
+            delegate.assertContent(archive, testFile);
+
+            int fileEntries = 0;
+            for (Node node : archive.getContent().values()) {
+                final Asset asset = node.getAsset();
+                if (asset == null) {
+                    continue;
+                }
+                fileEntries++;
+                Assertions.assertInstanceOf(ByteArrayAsset.class, asset,
+                        "In-memory path should use ByteArrayAsset but found " + asset.getClass().getSimpleName());
+            }
+            Assertions.assertTrue(fileEntries > 0, "Archive should contain at least one file entry");
+        }
+    }
+
+    /**
+     * Ensures that importing a stream larger than the disk buffer threshold
+     * spills to disk and still produces correct content.
+     */
+    @Test
+    public void shouldImportStreamViaDiskWhenAboveThreshold() throws Exception {
+        System.setProperty("shrinkwrap.zipImporter.diskBufferThresholdMb", "0");
+
+        final File testFile = delegate.getExistingResource();
+
+        try (InputStream stream = Files.newInputStream(testFile.toPath())) {
+            final Archive<?> archive = ShrinkWrap.create(ZipImporter.class, "test.jar")
+                    .importFrom(stream).as(JavaArchive.class);
+
+            Assertions.assertNotNull(archive, "Should not return a null archive");
+            delegate.assertContent(archive, testFile);
+
+            int fileEntries = 0;
+            for (Node node : archive.getContent().values()) {
+                final Asset asset = node.getAsset();
+                if (asset == null) {
+                    continue;
+                }
+                fileEntries++;
+                Assertions.assertInstanceOf(ZipFileEntryAsset.class, asset,
+                        "Disk spill path should use ZipFileEntryAsset but found " + asset.getClass().getSimpleName());
+            }
+            Assertions.assertTrue(fileEntries > 0, "Archive should contain at least one file entry");
+        }
+    }
 
     /**
      * SHRINKWRAP-259


### PR DESCRIPTION
fixes #190 

Buffer the InputStream to a temporary disk file instead of holding the entire archive in the Java Heap.