### PR TITLE
Add Automatic-Module-Name to api, spi, and impl-base modules

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -37,6 +37,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.jboss.shrinkwrap.api</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/impl-base/pom.xml
+++ b/impl-base/pom.xml
@@ -70,6 +70,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.jboss.shrinkwrap.impl.base</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -31,5 +31,22 @@
 
   </dependencies>
 
+  <!-- Build Configuration -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.jboss.shrinkwrap.spi</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>
 


### PR DESCRIPTION
Enables downstream modular applications (Piranha, Arquillian) to reference ShrinkWrap with stable JPMS module names instead of names derived from JAR filenames.

Closes #127
Closes #255